### PR TITLE
Change OND from cinemaproductions to cineproductions

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -2702,7 +2702,7 @@
   },
   {
     "code": "OND",
-    "description": "old/new cinemaproductions"
+    "description": "old/new cineproductions"
   },
   {
     "code": "ONE",


### PR DESCRIPTION
Email received: 

Dear Jerry,

the name should read „cineproductions“, not „cinemaproductions“.

Thanks and all the best,

Andreas

old / new cineproductions & events
Andreas Strouthos