### PR TITLE
Added requested fields to facilities and studios, updated schemas - closes #27

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -387,7 +387,7 @@
   },
   {
     "code": "BKH",
-    "description": "Blockhead VFX"
+    "description": "Blockhead VFX"  
   },
   {
     "code": "BL",
@@ -1047,7 +1047,8 @@
   },
   {
     "code": "DDR",
-    "description": "DELUXE ROME"
+    "description": "DELUXE ROME",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DDS",
@@ -1143,7 +1144,8 @@
   },
   {
     "code": "DLN",
-    "description": "DELUXE NEW YORK"
+    "description": "DELUXE NEW YORK",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DLS",
@@ -1237,11 +1239,18 @@
   },
   {
     "code": "DTA",
-    "description": "DELUXE AUSTRALIA"
+    "description": "DELUXE AUSTRALIA",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DTB",
-    "description": "DELUXE BURBANK "
+    "description": "DELUXE BURBANK ",
+    "url": "https://www.bydeluxe.com/",
+    "contact": {
+      "name": "Steve LLamb",
+      "email": "steve.llamb@bydeluxe.com",
+      "address": "2233 N Ontario Street, Suite 300, Burbank, CA, 91504, US"
+    }
   },
   {
     "code": "DTC",
@@ -1251,11 +1260,13 @@
   },
   {
     "code": "DTF",
-    "description": "DELUXE PARIS "
+    "description": "DELUXE PARIS ",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DTI",
-    "description": "Deluxe Bangalore (India) "
+    "description": "Deluxe Bangalore (India) ",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DTL",
@@ -1263,15 +1274,18 @@
   },
   {
     "code": "DTM",
-    "description": "DELUXE MADRID"
+    "description": "DELUXE MADRID",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DTT",
-    "description": "DELUXE TORONTO"
+    "description": "DELUXE TORONTO",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DTU",
-    "description": "DELUXE UK "
+    "description": "DELUXE UK ",
+    "url": "https://www.bydeluxe.com/" 
   },
   {
     "code": "DUB",
@@ -2704,7 +2718,8 @@
   },
   {
     "code": "OND",
-    "description": "old/new cineproductions"
+    "description": "old/new cineproductions",
+    "url": "www.oldnew.de"
   },
   {
     "code": "ONE",

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -387,7 +387,8 @@
   },
   {
     "code": "BKH",
-    "description": "Blockhead VFX"
+    "description": "Blockhead VFX",
+    "url": "https://www.blockheadvfx.com"
   },
   {
     "code": "BL",

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -247,7 +247,13 @@
   },
   {
     "code": "APP",
-    "description": "Arteus Post Production"
+    "description": "Arteus Post Production",
+    "url": "https://www.arteus.co.uk",
+    "contact": {
+      "name": "Ian Ballantyne",
+      "email": "ian.ballantyne@arteus.co.uk",
+      "address": "40 Dalintober Street, Glasgow G5 8NW, UK"
+    }
   },
   {
     "code": "APS",

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -387,7 +387,7 @@
   },
   {
     "code": "BKH",
-    "description": "Blockhead VFX"  
+    "description": "Blockhead VFX"
   },
   {
     "code": "BL",
@@ -2634,7 +2634,10 @@
   },
   {
     "code": "NUL",
-    "description": "Unspecified"
+    "description": "Unspecified",
+    "comments": [
+      "This code is only use in the CTT. If using 429-16 metadata, the absence of the <Facility> element shall denote the facility is 'Unspecified'"
+    ]
   },
   {
     "code": "NVL",
@@ -2719,7 +2722,7 @@
   {
     "code": "OND",
     "description": "old/new cineproductions",
-    "url": "www.oldnew.de"
+    "url": "http://www.oldnew.de"
   },
   {
     "code": "ONE",

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -21,7 +21,13 @@
   },
   {
     "code": "1VP",
-    "description": "123 Vision Pictures"
+    "description": "123 Vision Pictures",
+    "url": "https://www.123vp.com",
+    "contact": {
+      "name": "Mr.Ma",
+      "email": "mali@123vp.com",
+      "address": "Feiteng Art Space Zoom A, No.173,Caochangdi, Chaoyang district, Beijing, China"
+    }
   },
   {
     "code": "1Z1",
@@ -514,7 +520,13 @@
   },
    {
     "code": "CBT",
-    "description": "Cobalt Films"
+    "description": "Cobalt Films",
+    "url": "https://www.cobaltfilms.be/",
+    "contact": {
+      "name": "Mr. Loup Brenta",
+      "email": "info@cobaltfilms.be",
+      "address": "108c rue des tanneurs, 1000 Brussels, Belgium"
+    }
   },
    {
     "code": "CBX",
@@ -2573,7 +2585,13 @@
   },
   {
     "code": "NAF",
-    "description": "Non-Aligned Films"
+    "description": "Non-Aligned Films",
+    "url": "http://nonalignedfilms.com",
+    "contact": {
+      "name": "Mr. Stefan Ivančić",
+      "email": "info@nonalignedfilms.com",
+      "address": "Valjevska 8, 26000 Pančevo, Serbia"
+    }
   },
   {
     "code": "NAV",
@@ -3266,7 +3284,13 @@
   },
   {
     "code": "S4U",
-    "description": "Sub4u"
+    "description": "Sub4u",
+    "url": "http://www.sub4u.be",
+    "contact": {
+      "name": "Mr. Jean Timmerman",
+      "email": "jean@sub4u.be",
+      "address": "6, Sentier Kleindal, 1180 Bruxelles, Belgium"
+    }
   },
   {
     "code": "S76",

--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -329,7 +329,8 @@
   },
   {
     "code": "FYF",
-    "description": "Firefly Films"
+    "description": "Firefly Films",
+    "url": "https://www.fireflyfilms.co.nz"
   },
   {
     "code": "FZ",
@@ -653,7 +654,8 @@
   },
   {
     "code": "PLNK",
-    "description": "Plank Film"
+    "description": "Plank Film",
+    "url": "http://plankfilm.ee"
   },
   {
     "code": "PMF",

--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -606,7 +606,10 @@
   },
   {
     "code": "NULL",
-    "description": "Unspecified"
+    "description": "Unspecified",
+    "comments": [
+      "This code is only use in the CTT. If using 429-16 metadata, the absence of the <Distributor> element shall denote the studio is 'Unspecified'"
+    ]
   },
   {
     "code": "O2",

--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -171,7 +171,8 @@
   },
   {
     "code": "CJOY",
-    "description": "CINEJOY MOVIES GMBH"
+    "description": "CINEJOY MOVIES GMBH",
+    "url": "http://www.cinejoymovies.ch"
   },
   {
     "code": "CL",

--- a/src/main/schemas/facilities.schema.json
+++ b/src/main/schemas/facilities.schema.json
@@ -7,6 +7,25 @@
     "code" : {
         "type": "string",
         "pattern": "^[A-Z0-9]{2,3}$"
+    },
+    "url": {
+      "type": "string"
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+          "name": {
+              "type": "string"
+          },
+          "email": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(\\.[_a-z0-9]+)*@[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,15})$"
+          },
+          "address": {
+              "type": "string"
+          }
+      },
+      "required": [ "name", "email","address"]
     }
   },
   "type": "array",
@@ -24,6 +43,12 @@
           "obsolete": {
             "type": "boolean",
             "const": false
+          },
+          "url": {
+            "$ref": "#/definitions/url"
+          },
+          "contact": {
+            "$ref": "#/definitions/contact"
           },
           "comments": {
             "type": "array",
@@ -53,6 +78,12 @@
             "uniqueItems" : true,
             "minItems": 1,
             "items": { "$ref": "#/definitions/code" }
+          },
+          "url": {
+            "$ref": "#/definitions/url"
+          },
+          "contact": {
+            "$ref": "#/definitions/contact"
           },
           "comments": {
             "type": "array",

--- a/src/main/schemas/facilities.schema.json
+++ b/src/main/schemas/facilities.schema.json
@@ -10,7 +10,8 @@
     },
     "url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "pattern": "^http(s)?"
     },
     "contact": {
       "type": "object",

--- a/src/main/schemas/facilities.schema.json
+++ b/src/main/schemas/facilities.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "$id": "http://isdcf.com/ns/json-schemas/registries/facilities/1.0.0-beta.2",
+  "$id": "http://isdcf.com/ns/json-schemas/registries/facilities/1.0.0-beta.3",
   "$comment": "Copyright, ISDCF <info@isdcf.com>",
   "title": "Schema for the Facilities registry of the ISDCF",
   "definitions": {
@@ -9,7 +9,8 @@
         "pattern": "^[A-Z0-9]{2,3}$"
     },
     "url": {
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "contact": {
       "type": "object",
@@ -19,7 +20,7 @@
           },
           "email": {
               "type": "string",
-              "pattern": "^[a-z0-9]+(\\.[_a-z0-9]+)*@[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,15})$"
+              "format": "email"
           },
           "address": {
               "type": "string"

--- a/src/main/schemas/studios.schema.json
+++ b/src/main/schemas/studios.schema.json
@@ -10,7 +10,8 @@
     },
     "url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "pattern": "^http(s)?"
     },
     "contact": {
       "type": "object",

--- a/src/main/schemas/studios.schema.json
+++ b/src/main/schemas/studios.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "$id": "http://isdcf.com/ns/json-schemas/registries/studios/1.0.0-beta.1",
+  "$id": "http://isdcf.com/ns/json-schemas/registries/studios/1.0.0-beta.2",
   "$comment": "Copyright, ISDCF <info@isdcf.com>",
   "title": "Schema for the Studios Registry of the ISDCF",
   "definitions": {
@@ -9,7 +9,8 @@
         "pattern": "^[A-Z0-9]{2,4}$"
     },
     "url": {
-      "type": "string"
+      "type": "string",
+      "format": "uri"
     },
     "contact": {
       "type": "object",
@@ -19,7 +20,7 @@
           },
           "email": {
               "type": "string",
-              "pattern": "^[a-zA-Z0-9]+(\\.[_a-zA-Z0-9]+)*@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-z]{2,15})$"
+              "format": "email"
           },
           "address": {
               "type": "string"

--- a/src/main/schemas/studios.schema.json
+++ b/src/main/schemas/studios.schema.json
@@ -7,6 +7,25 @@
     "code" : {
         "type": "string",
         "pattern": "^[A-Z0-9]{2,4}$"
+    },
+    "url": {
+      "type": "string"
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+          "name": {
+              "type": "string"
+          },
+          "email": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]+(\\.[_a-zA-Z0-9]+)*@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-z]{2,15})$"
+          },
+          "address": {
+              "type": "string"
+          }
+      },
+      "required": [ "name", "email","address"]
     }
   },
   "type": "array",
@@ -24,6 +43,12 @@
           "obsolete": {
             "type": "boolean",
             "const": false
+          },
+          "url": {
+            "$ref": "#/definitions/url"
+          },
+          "contact": {
+            "$ref": "#/definitions/contact"
           },
           "comments": {
             "type": "array",
@@ -53,6 +78,12 @@
             "uniqueItems" : true,
             "minItems": 1,
             "items": { "$ref": "#/definitions/code" }
+          },
+          "url": {
+            "$ref": "#/definitions/url"
+          },
+          "contact": {
+            "$ref": "#/definitions/contact"
           },
           "comments": {
             "type": "array",

--- a/test/facilities.js
+++ b/test/facilities.js
@@ -14,9 +14,13 @@ describe("facilities schema", () => {
   it("correct validation", () => {
     assert.doesNotThrow(() => validate([
       { code: "AAA", description: "A A A" },
-      { code: "BBB", description: "B B B", obsolete: true },
-      { code: "CCC", description: "C C C", obsolete: true, comments: [ "foo", "bar" ] },
-      { code: "DDD", description: "D D D", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ] }
+      { code: "BBB", description: "B B B", url: "http://www.foo.com"},
+      { code: "CCC", description: "C C C", obsolete: true },
+      { code: "DDD", description: "D D D", obsolete: true, comments: [ "foo", "bar" ] },
+      { code: "EEE", description: "E E E", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ] },
+      { code: "FFF", description: "F F F", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ], url: "http://www.foo.com"},
+      { code: "GGG", description: "G G G", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ], contact: { name: "Bob Smith", email: "bob@foo.com", address: "1234 Main St., Anytown, State, Country" } },
+      { code: "HHH", description: "H H H", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ], url: "http://www.foo.com", contact: { name: "Bob Smith", email: "bob@foo.com", address: "1234 Main St., Anytown, State, Country" } }
     ]))
   })
 

--- a/test/studios.js
+++ b/test/studios.js
@@ -14,9 +14,13 @@ describe("studios schema", () => {
   it("correct validation", () => {
     assert.doesNotThrow(() => validate([
       { code: "AAA", description: "A A A" },
-      { code: "BBB", description: "B B B", obsolete: true },
-      { code: "CCC", description: "C C C", obsolete: true, comments: [ "foo", "bar" ] },
-      { code: "DDD", description: "D D D", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ] }
+      { code: "BBB", description: "B B B", url: "http://www.foo.com"},
+      { code: "CCC", description: "C C C", obsolete: true },
+      { code: "DDD", description: "D D D", obsolete: true, comments: [ "foo", "bar" ] },
+      { code: "EEE", description: "E E E", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ] },
+      { code: "FFF", description: "F F F", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ], url: "http://www.foo.com"},
+      { code: "GGG", description: "G G G", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ], contact: { name: "Bob Smith", email: "bob@foo.com", address: "1234 Main St., Anytown, State, Country" } },
+      { code: "HHH", description: "H H H", obsolete: true, comments: [ "foo", "bar" ], obsoletedBy: [ 'AAA', 'BBB' ], url: "http://www.foo.com", contact: { name: "Bob Smith", email: "bob@foo.com", address: "1234 Main St., Anytown, State, Country" } }
     ]))
   })
 


### PR DESCRIPTION
Updated the schema to allow for new fields on both Facilities and Studios.
- Added URLs for recently added entires for both registries (didn't add contact info - they didn't have the option to opt out at the time of info added via the google forms, 3 of 5 are EU companies)
- Added URLs for Deluxe facilities, and contact info for Deluxe Burbank as an example. 