### PR TITLE
fix value type for "pre"

### DIFF
--- a/src/main/data/contentmodifiers.json
+++ b/src/main/data/contentmodifiers.json
@@ -41,11 +41,11 @@
   {
     "cplMetadata": {
       "attribute": "status",
+      "attributeValue": "pre",
       "definingDoc": "SMPTE ST 429-16",
       "element": "VersionNumber",
       "metaType": "Element Attribute Value",
-      "scope": "http://www.smpte-ra.org/schemas/429-16/2014/CPL-Metadata",
-      "value": "pre"
+      "scope": "http://www.smpte-ra.org/schemas/429-16/2014/CPL-Metadata"
     },
     "dcncCode": "Pre",
     "dcncSortOrder": 4,


### PR DESCRIPTION
Messed up the key for value on "pre", schema check didn't catch it. 