### PR TITLE
Modify EEC to ECC for Eclair Classics

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -1492,7 +1492,7 @@
     "description": "EDIT STUDIOS"
   },
   {
-    "code": "EEC",
+    "code": "ECC",
     "description": "Eclair Classics",
     "url": "http://www.imageretrouvee.fr/"
   },


### PR DESCRIPTION
When preparing to send a "it's ready" note, I found I entered EED as their facility name, not the requested ECC. Oops.