### PR TITLE
Obsolted ADC by OWM - Per email

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -116,6 +116,10 @@
   {
     "code": "ADC",
     "description": "ARRI DIGITAL CINEMA"
+    "obsolete": true,
+    "obsoletedBy": [
+      "OWM"
+    ]
   },
   {
     "code": "ADE",

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -115,7 +115,7 @@
   },
   {
     "code": "ADC",
-    "description": "ARRI DIGITAL CINEMA"
+    "description": "ARRI DIGITAL CINEMA",
     "obsolete": true,
     "obsoletedBy": [
       "OWM"


### PR DESCRIPTION
Effective May 1? 

As you maybe know, ARRI Media was sold to an investor and is no part of ARRI anymore. We now belong to the Jake Seal Group and our new facility name will be ORWO Media Services GmbH. But all this will just be official at may 1st. 


_______________________________________________________​Martin SippelTeam Lead Digital Cinema Mastering/Technical Supervisor Transfer​ARRI Media GmbHBavariafilmplatz 7 / Haus 7, 82031 Grünwaldwww.arrimedia.de+49 89 6499-1832MSippel@arri.de | 