### PR TITLE
ADC - make it active again and add URL

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -116,10 +116,7 @@
   {
     "code": "ADC",
     "description": "ARRI DIGITAL CINEMA",
-    "obsolete": true,
-    "obsoletedBy": [
-      "OWM"
-    ]
+    "url": "https://arrimedia.de"
   },
   {
     "code": "ADE",


### PR DESCRIPTION
Per email from Martin Sippel return ADC to active list and remove "obsolete" indication.