### PR TITLE
Obsolete OWM and redirect to ADC

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -3005,11 +3005,11 @@
   {
     "code": "OWM",
     "description": "ORWO Media Services GmbH",
-    "url": "https://orwomedia.com",
     "obsolete": true,
     "obsoletedBy": [
       "ADC"
-    ]
+    ],
+    "url": "https://orwomedia.com"
   },
   {
     "code": "OXI",

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -3008,7 +3008,11 @@
   {
     "code": "OWM",
     "description": "ORWO Media Services GmbH",
-    "url": "https://orwomedia.com"
+    "url": "https://orwomedia.com",
+    "obsolete": true,
+    "obsoletedBy": [
+      "ADC"
+    ]
   },
   {
     "code": "OXI",


### PR DESCRIPTION
Per email from Martin Sippel stop using OWM as a facility code and return to old code.