### PR TITLE
MIJ - Removed detail address per email

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -2723,7 +2723,7 @@
   {
     "code": "MIJ",
     "contact": {
-      "address": "Martinstrasse 5/14, 1180 Wien, Vienna, Austria",
+      "address": "1180 Wien, Vienna, Austria",
       "email": "mirjam@bromundt.at",
       "name": "Mirjam Bromundt"
     },


### PR DESCRIPTION
thanks for adding me to your list! I was wondering if you could maybe take out my address in the list as it is as well where I live and I would like it to be not that prominent on the internet. If you could just write "1180 Wien, Vienna, Austria" and take the street out, that would be great! When filling in the form it was not clear to me that this info would be visible as well for everybody… 

Best
Mirjam Bromundt