### PR TITLE
Add BEE - BEE Movies

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -159,6 +159,11 @@
     "description": "Bad Blood Films"
   },
   {
+    "code": "BEE",
+    "description": "BEE Movies",
+    "url": "http://www.beemovies.co.uk"
+  },
+  {
     "code": "BF",
     "description": "BELARUSFILM"
   },


### PR DESCRIPTION
Opt OUT - 1) it's a http not https - it redirects to a secure WiX page. 2) they opted out, but tried to put location info in the studio name. I deleted it.