### PR TITLE
Remove OVS - Orbital Vox Studios

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -1039,16 +1039,6 @@
     "description": "OTL Releasing"
   },
   {
-    "code": "OVS",
-    "contact": {
-      "address": "C.R. Jakobsoni 14, Tallinn 10128, Estonia",
-      "email": "orbital@orbital.ee",
-      "name": "Mr. Uku Toomet"
-    },
-    "description": "Orbital Vox Studios",
-    "url": "https://www.orbital.ee"
-  },
-  {
     "code": "OVSP",
     "description": "OVERSPIL (DK)"
   },


### PR DESCRIPTION
Added in error. Via email they wanted to be a facility. Code has not been used.