### PR TITLE
Update Language schema

### DIFF
--- a/src/main/schemas/languages.schema.json
+++ b/src/main/schemas/languages.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "$id": "http://isdcf.com/ns/json-schemas/registries/languages/1.0.0",
+  "$id": "http://isdcf.com/ns/json-schemas/registries/languages/1.0.1",
   "$comment": "Copyright, ISDCF <info@isdcf.com>",
   "title": "Schema for the Languages Registry of the ISDCF",
   "type": "array",

--- a/src/main/schemas/languages.schema.json
+++ b/src/main/schemas/languages.schema.json
@@ -31,7 +31,7 @@
         "uniqueItems": true,
         "items": {
           "type": "string",
-          "enum": ["audio", "text"]
+          "enum": ["audio", "text", "sign"]
         }
       },
       "obsoleteDCNCTags" : {


### PR DESCRIPTION
Add "sign" usage type for Sign Languages in CPL metadata. This is meant ONLY for usage in CPL metadata, and specifically NOT for usage in CTT. The CTT convention is expected to remain unchanged with this addition. 