### PR TITLE
Update links to most recent 429-2

### DIFF
--- a/src/main/data/audioconfigs.json
+++ b/src/main/data/audioconfigs.json
@@ -9,8 +9,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",
@@ -32,8 +32,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",
@@ -55,8 +55,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",
@@ -122,8 +122,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",
@@ -145,8 +145,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",

--- a/src/main/data/projectoraspectratios.json
+++ b/src/main/data/projectoraspectratios.json
@@ -21,8 +21,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",
@@ -56,8 +56,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",
@@ -91,8 +91,8 @@
           "url": "https://doi.org/10.5594/SMPTE.ST429-16.2014"
         },
         {
-          "name": "SMPTE ST 429-2:2019",
-          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2019"
+          "name": "SMPTE ST 429-2:2020",
+          "url": "https://doi.org/10.5594/SMPTE.ST429-2.2020"
         },
         {
           "name": "SMPTE ST 428-12:2013",


### PR DESCRIPTION
Update 429-2 to 2020 and fix links to IEEE, closes https://github.com/ISDCF/registries-site/issues/49