### PR TITLE
Add ALTI - Altitude Film Entertainment

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -69,6 +69,11 @@
     "description": "ALTIMETER FILMS"
   },
   {
+    "code": "ALTI",
+    "description": "Altitude Film Entertainment",
+    "url": "http://www.altitudefilment.com/"
+  },
+  {
     "code": "AMBI",
     "description": "AMBI Media Group"
   },


### PR DESCRIPTION
Opt OUT - although the request did not opt out, the submission was from a post house that seemed to need to use a code so asked for it. I felt it better to not link to their contact info. The URL is not secure, it didn't resolve to a secure site.