### PR TITLE
Update territories with Macao SAR

### DIFF
--- a/src/main/data/territories.json
+++ b/src/main/data/territories.json
@@ -391,6 +391,11 @@
     "tag": "MN"
   },
   {
+    "dcncTag": "MO",
+    "dcncTerritory": "Macao",
+    "tag": "MO"
+  },
+  {
     "dcncTag": "MQ",
     "dcncTerritory": "Martinique",
     "tag": "MQ"


### PR DESCRIPTION
see [M49](https://unstats.un.org/unsd/methodology/m49/) entry:

Country or Area | M49 code | ISO-alpha3 code
-- | -- | --
China, Macao Special Administrative Region | 446 | MAC

It's sad that Macao is still missing while [North Korea got added today](https://github.com/ISDCF/registries/commit/c731ac32d5307733a755bedc75770f07429e2bd3) 😒