### PR TITLE
Normalize Chinese entries & add regional 4-letter DCNC tags

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -471,7 +471,7 @@
     ]
   },
   {
-    "dcncLanguage": "Chinese - Mandarin PRC",
+    "dcncLanguage": "Chinese - Mandarin",
     "dcncTag": "CMN",
     "rfc5646Tag": "cmn",
     "use": [
@@ -483,7 +483,7 @@
     "comments": [
       "(Subtitles only)"
     ],
-    "dcncLanguage": "Chinese - Mandarin Simplified",
+    "dcncLanguage": "Chinese - Mandarin - Simplified",
     "dcncTag": "QMS",
     "rfc5646Tag": "cmn-Hans",
     "use": [
@@ -491,11 +491,13 @@
     ]
   },
   {
-    "dcncLanguage": "Chinese - Mandarin Simplified - Singapore",
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Simplified - Singapore",
     "dcncTag": "CSSG",
     "rfc5646Tag": "cmn-Hans-SG",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -503,7 +505,7 @@
     "comments": [
       "(Subtitles only)"
     ],
-    "dcncLanguage": "Chinese - Mandarin Traditional",
+    "dcncLanguage": "Chinese - Mandarin - Traditional",
     "dcncTag": "QMT",
     "rfc5646Tag": "cmn-Hant",
     "use": [
@@ -511,15 +513,53 @@
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Simplified",
     "dcncTag": "ZHS",
     "rfc5646Tag": "zh-Hans",
     "use": [
-      "audio",
       "text"
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Simplified - China mainland",
+    "dcncTag": "ZSCN",
+    "rfc5646Tag": "zh-Hans-CN",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Simplified - Hong Kong",
+    "dcncTag": "ZSHK",
+    "rfc5646Tag": "zh-Hans-HK",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Simplified - Macao",
+    "dcncTag": "ZSMO",
+    "rfc5646Tag": "zh-Hans-MO",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Simplified - Malaysia",
     "dcncTag": "ZSMY",
     "rfc5646Tag": "zh-Hans-MY",
@@ -528,33 +568,38 @@
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Simplified - Singapore",
     "dcncTag": "ZSSG",
     "rfc5646Tag": "zh-Hans-SG",
     "use": [
-      "audio",
       "text"
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Simplified - Taiwan ",
     "dcncTag": "ZSTW",
     "rfc5646Tag": "zh-Hans-TW",
     "use": [
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Chinese - Min Nan",
+    "dcncTag": "NAN",
+    "rfc5646Tag": "nan",
+    "use": [
       "audio",
       "text"
     ]
   },
   {
-    "dcncLanguage": "Chinese - Taiwanese - Min Nan",
-    "dcncTag": "NAN",
-    "rfc5646Tag": "nan",
-    "use": [
-      "audio"
-    ]
-  },
-  {
-    "dcncLanguage": "Chinese - Taiwanese Mandarin",
+    "dcncLanguage": "Chinese - Mandarin - Taiwan",
     "dcncTag": "QTM",
     "rfc5646Tag": "cmn-TW",
     "use": [
@@ -562,46 +607,79 @@
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Traditional",
     "dcncTag": "ZHT",
     "rfc5646Tag": "zh-Hant",
     "use": [
-      "audio",
       "text"
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Traditional - China mainland",
+    "dcncTag": "ZTCN",
+    "rfc5646Tag": "zh-Hant-CN",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Traditional - Hong Kong",
     "dcncTag": "ZTHK",
     "rfc5646Tag": "zh-Hant-HK",
     "use": [
-      "audio",
       "text"
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Traditional - Macao SAR",
     "dcncTag": "ZTMO",
     "rfc5646Tag": "zh-Hant-MO",
     "use": [
-      "audio",
       "text"
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Traditional - Malaysia",
     "dcncTag": "ZTMY",
     "rfc5646Tag": "zh-Hant-MY",
     "use": [
-      "audio"
+      "text"
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Traditional - Singapore",
+    "dcncTag": "ZTSG",
+    "rfc5646Tag": "zh-Hant-SG",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Traditional - Taiwan",
     "dcncTag": "ZTTW",
     "rfc5646Tag": "zh-Hant-TW",
     "use": [
-      "audio",
       "text"
     ]
   },

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -502,6 +502,14 @@
     ]
   },
   {
+    "dcncLanguage": "Chinese - Mandarin - Taiwan",
+    "dcncTag": "QTM",
+    "rfc5646Tag": "cmn-TW",
+    "use": [
+      "audio"
+    ]
+  },
+  {
     "comments": [
       "(Subtitles only)"
     ],
@@ -509,6 +517,15 @@
     "dcncTag": "QMT",
     "rfc5646Tag": "cmn-Hant",
     "use": [
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Chinese - Min Nan",
+    "dcncTag": "NAN",
+    "rfc5646Tag": "nan",
+    "use": [
+      "audio",
       "text"
     ]
   },
@@ -587,23 +604,6 @@
     "rfc5646Tag": "zh-Hans-TW",
     "use": [
       "text"
-    ]
-  },
-  {
-    "dcncLanguage": "Chinese - Min Nan",
-    "dcncTag": "NAN",
-    "rfc5646Tag": "nan",
-    "use": [
-      "audio",
-      "text"
-    ]
-  },
-  {
-    "dcncLanguage": "Chinese - Mandarin - Taiwan",
-    "dcncTag": "QTM",
-    "rfc5646Tag": "cmn-TW",
-    "use": [
-      "audio"
     ]
   },
   {

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -576,6 +576,72 @@
     ]
   },
   {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Traditional - China mainland",
+    "dcncTag": "CTCN",
+    "rfc5646Tag": "cmn-Hant-CN",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Traditional - Hong Kong",
+    "dcncTag": "CTHK",
+    "rfc5646Tag": "cmn-Hant-HK",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Traditional - Macao",
+    "dcncTag": "CTMO",
+    "rfc5646Tag": "cmn-Hant-MO",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Traditional - Malaysia",
+    "dcncTag": "CTMY",
+    "rfc5646Tag": "cmn-Hant-MY",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Traditional - Singapore",
+    "dcncTag": "CTSG",
+    "rfc5646Tag": "cmn-Hant-SG",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Traditional - Taiwan",
+    "dcncTag": "CTTW",
+    "rfc5646Tag": "cmn-Hant-TW",
+    "use": [
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Chinese - Min Nan",
     "dcncTag": "NAN",
     "rfc5646Tag": "nan",

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -475,7 +475,7 @@
     "dcncTag": "CMN",
     "rfc5646Tag": "cmn",
     "use": [
-      "text"
+      "audio"
     ]
   },
   {

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -475,7 +475,6 @@
     "dcncTag": "CMN",
     "rfc5646Tag": "cmn",
     "use": [
-      "audio",
       "text"
     ]
   },

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -645,8 +645,7 @@
     "dcncTag": "NAN",
     "rfc5646Tag": "nan",
     "use": [
-      "audio",
-      "text"
+      "audio"
     ]
   },
   {

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -471,6 +471,9 @@
     ]
   },
   {
+    "comments": [
+      "(Audio only)"
+    ],
     "dcncLanguage": "Chinese - Mandarin",
     "dcncTag": "CMN",
     "rfc5646Tag": "cmn",
@@ -641,6 +644,9 @@
     ]
   },
   {
+    "comments": [
+      "(Audio only)"
+    ],
     "dcncLanguage": "Chinese - Min Nan",
     "dcncTag": "NAN",
     "rfc5646Tag": "nan",

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -494,9 +494,64 @@
     "comments": [
       "(Subtitles only)"
     ],
+    "dcncLanguage": "Chinese - Mandarin - Simplified - China mainland",
+    "dcncTag": "CSCN",
+    "rfc5646Tag": "cmn-Hans-CN",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Simplified - Hong Kong",
+    "dcncTag": "CSHK",
+    "rfc5646Tag": "cmn-Hans-HK",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Simplified - Macao",
+    "dcncTag": "CSMO",
+    "rfc5646Tag": "cmn-Hans-MO",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Simplified - Malaysia",
+    "dcncTag": "CSMY",
+    "rfc5646Tag": "cmn-Hans-MY",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
     "dcncLanguage": "Chinese - Mandarin - Simplified - Singapore",
     "dcncTag": "CSSG",
     "rfc5646Tag": "cmn-Hans-SG",
+    "use": [
+      "text"
+    ]
+  },
+  {
+    "comments": [
+      "(Subtitles only)"
+    ],
+    "dcncLanguage": "Chinese - Mandarin - Simplified - Taiwan",
+    "dcncTag": "CSTW",
+    "rfc5646Tag": "cmn-Hans-TW",
     "use": [
       "text"
     ]

--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -35,6 +35,11 @@
     "description": "ALLIANCE DIGITAL STUDIOS"
   },
   {
+    "code": "AER",
+    "description": "AN AER",
+    "url": "https://an-aer.bzh"
+  },
+  {
     "code": "AFG",
     "description": "ARCHANGEL FILM GROUP"
   },


### PR DESCRIPTION
`Hans` & `Hant` entries should always be picture-and-text-only.

Description is made up in this order: 
`cmn-Hans-SG` => `zh-cmn-Hans-SG` => Chinese (`zh`) - Mandarin (`cmn`) - Han Simplified variant (`Hans`) - Singapore (`SG`)

I'm only adding missing 4-letter tags that are non-controversial and easy to construct (`ZSxx` & `ZTxx`).

Other frequently used but missing candidates aren't included in this PR, like:

- `cmn-CN` - Chinese, Mandarin, China mainland (re-dubbed Mandarin audio, different from the original Mandarin audio)
- `nan-TW` - Chinese, Min Nan, Taiwan (this is what people actually call _Taiwanese_ in real life, but not recommend as critics say it weakens other dialects' position in Taiwan; studios simply use `NAN` right now)

Closes #421 
Closes #422