### PR TITLE
Territories: update short names for CN & KP

### DIFF
--- a/src/main/data/territories.json
+++ b/src/main/data/territories.json
@@ -106,7 +106,7 @@
   },
   {
     "dcncTag": "CN",
-    "dcncTerritory": "China mainland",
+    "dcncTerritory": "China Mainland",
     "tag": "CN"
   },
   {

--- a/src/main/data/territories.json
+++ b/src/main/data/territories.json
@@ -106,7 +106,7 @@
   },
   {
     "dcncTag": "CN",
-    "dcncTerritory": "China",
+    "dcncTerritory": "China mainland",
     "tag": "CN"
   },
   {
@@ -307,7 +307,7 @@
   },
   {
     "dcncTag": "KP",
-    "dcncTerritory": "Democratic People's Republic of Korea",
+    "dcncTerritory": "North Korea",
     "tag": "KP"
   },
   {


### PR DESCRIPTION
Closes #420 

For `CN`: 
The purpose of the territory tag is to distinguish between different regional versions. 
`CN` versions (often suffixed with `-Censor` in their titles) are often specially mastered for the mainland China, i.e. the [WTO-defined China](https://www.wto.org/english/thewto_e/countries_e/china_e.htm) ([see map](https://www.wto.org/english/res_e/statis_e/statis_maps_iframe_e.htm?country_selected=CHN&optionSelected=3)), which is the UN-defined China ([map at WHO](https://covid19.who.int/)) with `HK`, `MO` & `TW` excluded.

I'm trying to use lowercased '_mainland_' to specifically target this WTO customs territory, which doesn't cover `HK` & `MO`. This hasn't been a common convention/practice and can be discussed.
The native name for this geographic area (the WTO-defined China) is 中国**内地** (_Zhōngguó **nèidì**_), which literally translates to "China _Inner_-land". This "nèidì" is the correct name for this customs territory as seen in formal texts like [legislation](https://www.elegislation.gov.hk/hk/cap597!en-zh-Hant-HK). 
Other political terms like 中国**大陆** (... **dàlù**; _Main_-land) currently used by tech giants like Apple ([en](https://support.apple.com/en-gb/HT208351) vs [zh](https://support.apple.com/zh-cn/HT208351)) actually covers `HK` & `MO` <sup>[1]</sup>, which is inappropriate for the ISDCF use cases. (DCPs are always sent to their respective customs territories.)
Both terms translate to "_China Mainland_" in English. That's why I tried to distinguish them by lower and upper cases.

Take Fujian province for example, `TW` versions were sent to Kinmen county of Fujian, while the rest cinemas were sent censored `CN` versions. This is how the WTO concept works in the real world.

For `KP`:
The existing `KR` entry has been called "South Korea" for years. 
`KP` was added a month ago in c731ac3 and this commonly-known short name looks better in this registry.

[1] One significant proof is the 2015 Xi-Ma meeting in Singapore, where Mr. Xi and Mr. Ma were referred to as "Leader of Mainland China" (_Dàlù_ leader) and "Leader of Taiwan" (Taiwan leader).