### PR TITLE
languages: remove audio usage from script entries

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -243,7 +243,6 @@
     "dcncTag": "AZCY",
     "rfc5646Tag": "az-Cyrl",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -252,7 +251,6 @@
     "dcncTag": "AZLT",
     "rfc5646Tag": "az-Latn",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -309,7 +307,6 @@
     "dcncTag": "BSCY",
     "rfc5646Tag": "bs-Cyrl",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -385,7 +382,6 @@
     "dcncTag": "TZMA",
     "rfc5646Tag": "tzm-Arab-MA",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -403,7 +399,6 @@
     "dcncTag": "TZMT",
     "rfc5646Tag": "tzm-Tfng",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -412,7 +407,6 @@
     "dcncTag": "TZMM",
     "rfc5646Tag": "tzm-Tfng-MA",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1327,7 +1321,6 @@
     "dcncTag": "FFL",
     "rfc5646Tag": "ff-Latn",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1336,7 +1329,6 @@
     "dcncTag": "FFLN",
     "rfc5646Tag": "ff-Latn-NG",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1345,7 +1337,6 @@
     "dcncTag": "FFLS",
     "rfc5646Tag": "ff-Latn-SN",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1470,7 +1461,6 @@
     "dcncTag": "HALT",
     "rfc5646Tag": "ha-Latn",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1479,7 +1469,6 @@
     "dcncTag": "HALN",
     "rfc5646Tag": "ha-Latn-NG",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1582,7 +1571,6 @@
     "dcncTag": "IUC",
     "rfc5646Tag": "iu-Cans",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1687,7 +1675,6 @@
     "dcncTag": "KSDI",
     "rfc5646Tag": "ks-Deva-IN",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1894,7 +1881,6 @@
     "dcncTag": "MNBI",
     "rfc5646Tag": "mni-Beng-IN",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1948,7 +1934,6 @@
     "dcncTag": "MNMT",
     "rfc5646Tag": "mn-Mong",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -1957,7 +1942,6 @@
     "dcncTag": "MNMC",
     "rfc5646Tag": "mn-Mong-CN",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2128,7 +2112,6 @@
     "dcncTag": "PJA",
     "rfc5646Tag": "pa-Arab",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2373,7 +2356,6 @@
     "dcncTag": "SRCY",
     "rfc5646Tag": "sr-Cyrl",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2382,7 +2364,6 @@
     "dcncTag": "SRCB",
     "rfc5646Tag": "sr-Cyrl-BA",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2391,7 +2372,6 @@
     "dcncTag": "SYCM",
     "rfc5646Tag": "sr-Cyrl-ME",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2400,7 +2380,6 @@
     "dcncTag": "SRLT",
     "rfc5646Tag": "sr-Latn",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2409,7 +2388,6 @@
     "dcncTag": "SRLB",
     "rfc5646Tag": "sr-Latn-BA",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2418,7 +2396,6 @@
     "dcncTag": "SRLM",
     "rfc5646Tag": "sr-Latn-ME",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2436,7 +2413,6 @@
     "dcncTag": "SDAR",
     "rfc5646Tag": "sd-Arab",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2445,7 +2421,6 @@
     "dcncTag": "SIN",
     "rfc5646Tag": "sd-Deva-IN",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2791,7 +2766,6 @@
     "dcncTag": "TGCY",
     "rfc5646Tag": "tg-Cyrl",
     "use": [
-      "audio",
       "text"
     ]
   },
@@ -2800,7 +2774,6 @@
     "dcncTag": "TGCT",
     "rfc5646Tag": "tg-Cyrl-TJ",
     "use": [
-      "audio",
       "text"
     ]
   },


### PR DESCRIPTION
Language tags with a script tag explictly specified should only be used for text purposes (picture / subtitles)

Closes #424 