### PR TITLE
languages: complement region-specific entries

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2370,14 +2370,6 @@
     ]
   },
   {
-    "dcncLanguage": "Serbian - Bosnia and Herzegovina",
-    "dcncTag": "SRBA",
-    "rfc5646Tag": "sr-BA",
-    "use": [
-      "audio"
-    ]
-  },
-  {
     "dcncLanguage": "Serbian - Cyrillic",
     "dcncTag": "SRCY",
     "rfc5646Tag": "sr-Cyrl",
@@ -2431,14 +2423,6 @@
     ]
   },
   {
-    "dcncLanguage": "Serbian - Montenegro",
-    "dcncTag": "SRME",
-    "rfc5646Tag": "sr-ME",
-    "use": [
-      "audio"
-    ]
-  },
-  {
     "dcncLanguage": "Sindhi",
     "dcncTag": "SD",
     "rfc5646Tag": "sd",
@@ -2462,14 +2446,6 @@
     "use": [
       "audio",
       "text"
-    ]
-  },
-  {
-    "dcncLanguage": "Sindhi - India",
-    "dcncTag": "SDIN",
-    "rfc5646Tag": "sd-IN",
-    "use": [
-      "audio"
     ]
   },
   {

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -1491,15 +1491,6 @@
     ]
   },
   {
-    "dcncLanguage": "Hausa - Nigeria",
-    "dcncTag": "HANG",
-    "rfc5646Tag": "ha-NG",
-    "use": [
-      "audio",
-      "text"
-    ]
-  },
-  {
     "dcncLanguage": "Hawaiian",
     "dcncTag": "HAW",
     "rfc5646Tag": "haw",
@@ -1706,15 +1697,6 @@
     ]
   },
   {
-    "dcncLanguage": "Kashmiri - India",
-    "dcncTag": "KSIN",
-    "rfc5646Tag": "ks-IN",
-    "use": [
-      "audio",
-      "text"
-    ]
-  },
-  {
     "dcncLanguage": "Kazakh",
     "dcncTag": "KK",
     "rfc5646Tag": "kk",
@@ -1917,15 +1899,6 @@
     "dcncTag": "MNBI",
     "rfc5646Tag": "mni-Beng-IN",
     "use": [
-      "text"
-    ]
-  },
-  {
-    "dcncLanguage": "Manipuri - India",
-    "dcncTag": "MNIN",
-    "rfc5646Tag": "mni-IN",
-    "use": [
-      "audio",
       "text"
     ]
   },
@@ -2858,15 +2831,6 @@
     "dcncTag": "TGCT",
     "rfc5646Tag": "tg-Cyrl-TJ",
     "use": [
-      "text"
-    ]
-  },
-  {
-    "dcncLanguage": "Tajik - Tajikistan",
-    "dcncTag": "TGTJ",
-    "rfc5646Tag": "tg-TJ",
-    "use": [
-      "audio",
       "text"
     ]
   },

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2379,7 +2379,10 @@
   },
   {
     "dcncLanguage": "Serbian - Cyrillic - Bosnia and Herzegovina",
-    "dcncTag": "SRCB",
+    "dcncTag": "SRBA",
+    "obsoleteDCNCTags": [
+      "SRCB"
+    ],
     "rfc5646Tag": "sr-BA",
     "use": [
       "audio",
@@ -2415,7 +2418,10 @@
   },
   {
     "dcncLanguage": "Serbian - Latin - Montenegro",
-    "dcncTag": "SRLM",
+    "dcncTag": "SRME",
+    "obsoleteDCNCTags": [
+      "SRLM"
+    ],
     "rfc5646Tag": "sr-ME",
     "use": [
       "audio",

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2384,7 +2384,6 @@
     "rfc5646Tag": "sr-BA",
     "use": [
       "audio",
-      "text"
     ]
   },
   {
@@ -2444,7 +2443,6 @@
     "rfc5646Tag": "sr-ME",
     "use": [
       "audio",
-      "text"
     ]
   },
   {

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -1350,6 +1350,24 @@
     ]
   },
   {
+    "dcncLanguage": "Fulah - Nigeria",
+    "dcncTag": "FFNG",
+    "rfc5646Tag": "ff-NG",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Fulah - Senegal",
+    "dcncTag": "FFSN",
+    "rfc5646Tag": "ff-SN",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Galician",
     "dcncTag": "GL",
     "rfc5646Tag": "gl",
@@ -1478,6 +1496,15 @@
     "dcncLanguage": "Hausa - Latin - Nigeria",
     "dcncTag": "HALN",
     "rfc5646Tag": "ha-Latn-NG",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Hausa - Nigeria",
+    "dcncTag": "HANG",
+    "rfc5646Tag": "ha-NG",
     "use": [
       "audio",
       "text"
@@ -1692,6 +1719,15 @@
     ]
   },
   {
+    "dcncLanguage": "Kashmiri - India",
+    "dcncTag": "KSIN",
+    "rfc5646Tag": "ks-IN",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Kazakh",
     "dcncTag": "KK",
     "rfc5646Tag": "kk",
@@ -1899,6 +1935,15 @@
     ]
   },
   {
+    "dcncLanguage": "Manipuri - India",
+    "dcncTag": "MNIN",
+    "rfc5646Tag": "mni-IN",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Maori",
     "dcncTag": "MI",
     "rfc5646Tag": "mi",
@@ -1938,6 +1983,15 @@
     "dcncLanguage": "Mongolian",
     "dcncTag": "MN",
     "rfc5646Tag": "mn",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Mongolian - China",
+    "dcncTag": "MNCN",
+    "rfc5646Tag": "mn-CN",
     "use": [
       "audio",
       "text"
@@ -2369,6 +2423,15 @@
     ]
   },
   {
+    "dcncLanguage": "Serbian - Bosnia and Herzegovina",
+    "dcncTag": "SRBA",
+    "rfc5646Tag": "sr-BA",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Serbian - Cyrillic",
     "dcncTag": "SRCY",
     "rfc5646Tag": "sr-Cyrl",
@@ -2423,6 +2486,15 @@
     ]
   },
   {
+    "dcncLanguage": "Serbian - Montenegro",
+    "dcncTag": "SRME",
+    "rfc5646Tag": "sr-ME",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Sindhi",
     "dcncTag": "SD",
     "rfc5646Tag": "sd",
@@ -2444,6 +2516,15 @@
     "dcncLanguage": "Sindhi - Devanagari - India",
     "dcncTag": "SIN",
     "rfc5646Tag": "sd-Deva-IN",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Sindhi - India",
+    "dcncTag": "SDIN",
+    "rfc5646Tag": "sd-IN",
     "use": [
       "audio",
       "text"
@@ -2799,6 +2880,15 @@
     "dcncLanguage": "Tajik - Cyrillic - Tajikistan",
     "dcncTag": "TGCT",
     "rfc5646Tag": "tg-Cyrl-TJ",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Tajik - Tajikistan",
+    "dcncTag": "TGTJ",
+    "rfc5646Tag": "tg-TJ",
     "use": [
       "audio",
       "text"

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2475,8 +2475,7 @@
     "dcncTag": "SDIN",
     "rfc5646Tag": "sd-IN",
     "use": [
-      "audio",
-      "text"
+      "audio"
     ]
   },
   {

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2383,7 +2383,7 @@
     "dcncTag": "SRBA",
     "rfc5646Tag": "sr-BA",
     "use": [
-      "audio",
+      "audio"
     ]
   },
   {
@@ -2442,7 +2442,7 @@
     "dcncTag": "SRME",
     "rfc5646Tag": "sr-ME",
     "use": [
-      "audio",
+      "audio"
     ]
   },
   {

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -1350,15 +1350,6 @@
     ]
   },
   {
-    "dcncLanguage": "Fulah - Senegal",
-    "dcncTag": "FFSN",
-    "rfc5646Tag": "ff-SN",
-    "use": [
-      "audio",
-      "text"
-    ]
-  },
-  {
     "dcncLanguage": "Galician",
     "dcncTag": "GL",
     "rfc5646Tag": "gl",

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2388,8 +2388,9 @@
   {
     "dcncLanguage": "Serbian - Cyrillic - Bosnia and Herzegovina",
     "dcncTag": "SRCB",
-    "rfc5646Tag": "sr-Cyrl-BA",
+    "rfc5646Tag": "sr-BA",
     "use": [
+      "audio",
       "text"
     ]
   },
@@ -2423,8 +2424,9 @@
   {
     "dcncLanguage": "Serbian - Latin - Montenegro",
     "dcncTag": "SRLM",
-    "rfc5646Tag": "sr-Latn-ME",
+    "rfc5646Tag": "sr-ME",
     "use": [
+      "audio",
       "text"
     ]
   },
@@ -2456,8 +2458,9 @@
   {
     "dcncLanguage": "Sindhi - Devanagari - India",
     "dcncTag": "SIN",
-    "rfc5646Tag": "sd-Deva-IN",
+    "rfc5646Tag": "sd-IN",
     "use": [
+      "audio",
       "text"
     ]
   },


### PR DESCRIPTION
As a result of my recent changes on usage purposes ([tags with script tag became text-only](https://github.com/ISDCF/registries/pull/423)), people will be unable to mark a track as targeting one specific territory under affected languages. 
This PR allows existing customers a corresponding choice.

DCNC codes are made up following existing 4-letter style (`LLTT`, language code + territory code).

Closes #426 