### PR TITLE
languages: use SRCM for "Serbian - Cyrillic - Montenegro"

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2388,7 +2388,10 @@
   },
   {
     "dcncLanguage": "Serbian - Cyrillic - Montenegro",
-    "dcncTag": "SYCM",
+    "dcncTag": "SRCM",
+    "obsoleteDCNCTags": [
+      "SYCM"
+    ],
     "rfc5646Tag": "sr-Cyrl-ME",
     "use": [
       "audio",


### PR DESCRIPTION
I believe this is a typo.

Closes #427 