### PR TITLE
fix Dari language (mislabeled)

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -878,8 +878,8 @@
   },
   {
     "dcncLanguage": "Dari",
-    "dcncTag": "PRD",
-    "rfc5646Tag": "prd",
+    "dcncTag": "PRS",
+    "rfc5646Tag": "prs",
     "use": [
       "audio",
       "text"
@@ -2069,6 +2069,15 @@
     "dcncLanguage": "Papiamento - Caribbean",
     "dcncTag": "PAPC",
     "rfc5646Tag": "pap-029",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
+    "dcncLanguage": "Parsi-Dari",
+    "dcncTag": "PRD",
+    "rfc5646Tag": "prd",
     "use": [
       "audio",
       "text"

--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2075,15 +2075,6 @@
     ]
   },
   {
-    "dcncLanguage": "Parsi-Dari",
-    "dcncTag": "PRD",
-    "rfc5646Tag": "prd",
-    "use": [
-      "audio",
-      "text"
-    ]
-  },
-  {
     "dcncLanguage": "Pashto",
     "dcncTag": "PS",
     "rfc5646Tag": "ps",


### PR DESCRIPTION
Dari updated to proper code `PRS` for use in Afghanistan

A recent CPL was mislabeled with the wrong code `PRD` (Parsi-Dari, as used in Iran) was going to Afghanistan. This will prevent future mistakes. 

Closes #441 