### PR TITLE
feature: don't allow additional info in cplMetadata

### DIFF
--- a/src/main/schemas/contentmodifiers.schema.json
+++ b/src/main/schemas/contentmodifiers.schema.json
@@ -58,7 +58,8 @@
             }
           }
       },
-      "required": [ "metaType", "definingDocs"]
+      "required": [ "metaType", "definingDocs"],
+      "additionalProperties": false
     }
   },
   "type": "array",


### PR DESCRIPTION
This closes #476 by prohibiting additional properties on the `cplMetadata` object.
