### PR TITLE
Update schema for CM Extensions

### DIFF
--- a/src/main/schemas/contentmodifiers.schema.json
+++ b/src/main/schemas/contentmodifiers.schema.json
@@ -56,9 +56,23 @@
                 }
               }
             }
+          },
+          "extName": {
+              "type": "string"
+          },
+          "extpropName": {
+              "type": "string"
+          },
+          "extpropValue": {
+              "type": "string"
+          },
+          "extScope": {
+              "type": "string",
+              "format": "uri"
           }
       },
-      "required": [ "metaType", "definingDocs"]
+      "required": [ "metaType", "definingDocs"],
+      "additionalProperties": false
     }
   },
   "type": "array",


### PR DESCRIPTION
Update to accommodate extensions, as intended. Those were not a mistake in the JSON, they were not added to the schema on accident. 

closes #476.

Supersedes #487 and #489 