### PR TITLE
Update ATMOS as legacy - audio configs

### DIFF
--- a/src/main/data/audioconfigs.json
+++ b/src/main/data/audioconfigs.json
@@ -184,7 +184,7 @@
     "dcncCode": "ATMOS",
     "dcncSortOrder": 11,
     "description": "Dolby ATMOS Immersive Audio",
-    "note": "Legacy, replaced by Immersive Audio Bitstream (SMPTE ST2098-2) Profile 1"
+    "note": "Legacy. IAB [Immersive Audio Bitstream (SMPTE ST2098-2) Profile 1] should be used instead."
   },
   {
     "dcncCode": "AURO",

--- a/src/main/data/audioconfigs.json
+++ b/src/main/data/audioconfigs.json
@@ -184,7 +184,7 @@
     "dcncCode": "ATMOS",
     "dcncSortOrder": 11,
     "description": "Dolby ATMOS Immersive Audio",
-    "note": "Expect a change in the way ATMOS content is labeled! IAB (Immersive Audio Bitstream) is the SMPTE standard for Immersive Audio. All ATMOS is IAB Profile 1. Many authoring companies are planning to stop labeling ATMOS and using the IAB label only."
+    "note": "Legacy, replaced by Immesive Audio Bitstream (SMPTE ST2098-2) Profile 1"
   },
   {
     "dcncCode": "AURO",

--- a/src/main/data/audioconfigs.json
+++ b/src/main/data/audioconfigs.json
@@ -110,7 +110,7 @@
     },
     "dcncCode": "IAB",
     "dcncSortOrder": 7,
-    "description": "Immesive Audio Bitstream (SMPTE ST2098-2) Profile 1"
+    "description": "Immersive Audio Bitstream (SMPTE ST2098-2) Profile 1"
   },
   {
     "cplMetadata": {
@@ -184,7 +184,7 @@
     "dcncCode": "ATMOS",
     "dcncSortOrder": 11,
     "description": "Dolby ATMOS Immersive Audio",
-    "note": "Legacy, replaced by Immesive Audio Bitstream (SMPTE ST2098-2) Profile 1"
+    "note": "Legacy, replaced by Immersive Audio Bitstream (SMPTE ST2098-2) Profile 1"
   },
   {
     "dcncCode": "AURO",

--- a/src/main/data/audioconfigs.json
+++ b/src/main/data/audioconfigs.json
@@ -184,7 +184,7 @@
     "dcncCode": "ATMOS",
     "dcncSortOrder": 11,
     "description": "Dolby ATMOS Immersive Audio",
-    "note": "Legacy. IAB [Immersive Audio Bitstream (SMPTE ST2098-2) Profile 1] should be used instead."
+    "note": "Deprecated. The IAB code should be used instead."
   },
   {
     "dcncCode": "AURO",


### PR DESCRIPTION
Closes #438 

As noted in the above issue, permission has now been granted by a studio for an exhibitor to service IAB Profile 1 for DTSX equipment. ATMOS has been marked as "Legacy" in the notes. 