### PR TITLE
Obsolete UDS

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -5263,7 +5263,11 @@
   },
   {
     "code": "UDS",
-    "description": "UNIVERSAL STUDIOS DIGITAL SERVICES"
+    "description": "UNIVERSAL STUDIOS DIGITAL SERVICES",
+    "obsolete": true,
+    "obsoletedBy": [
+      "USP"
+    ]
   },
   {
     "code": "UF",


### PR DESCRIPTION
Per Email: 
Hi Jerry,
Please list as Deprecated the facility entry for UDS (Universal Studios Digital Services).  It’s Replaced by: USP (Universal StudioPost). Many thanks!
-Wade