### PR TITLE
Update term schema for media types

### DIFF
--- a/src/main/data/terms.json
+++ b/src/main/data/terms.json
@@ -142,6 +142,12 @@
   },
   {
     "definition": "The DX115DC system, manufactured by CRU, Inc., consists of portable cartridges into which 2.5in or 3.5in SATA hard drives can be installed, and readers that are integrated into DCP servers and TMS computers.  Its purpose is to protect drives in shipping, and to enable quick and easy insertion and removal of DCP hard drives in the theater.  External readers with USB connectivity are available for use with servers that do not have them built in.  CRU DX115DC cartridges are the industry standard for the distribution of DCPs on physical media, used by all the major studios and many independent distributors.",
+    "media": {
+      "photo": [
+        "https://www.cru-inc.com/scripts/thumbnail.php?w=800&h=450&pic=/product_image_galleries/Digital_Cinema_DX115/2-Data_Express_DX115_Carrier.png",
+        "https://www.cru-inc.com/scripts/thumbnail.php?w=800&h=450&pic=/product_image_galleries/Digital_Cinema_DX115/1-Data_Express_DX115.png"
+      ]
+    },
     "relatedTerms": [
       "DCP Server",
       "Theater Management System"
@@ -474,6 +480,11 @@
     "abbreviations": [
       "IAB"
     ],
+    "media": {
+      "video": [
+        "https://www.youtube.com/embed/U50WYIvo98k"
+      ]
+    },
     "sources": [
       "https://doi.org/10.5594/SMPTE.RDD57.2021"
     ],

--- a/src/main/schemas/terms.schema.json
+++ b/src/main/schemas/terms.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "$id": "http://isdcf.com/ns/json-schemas/registries/terms/1.0.0-beta.1",
+  "$id": "http://isdcf.com/ns/json-schemas/registries/terms/1.0.0-beta.2",
   "$comment": "Copyright, ISDCF <info@isdcf.com>",
   "title": "Schema for the Terms Registry of the ISDCF",
   "type": "array",
@@ -16,13 +16,36 @@
       "definition": {
         "type": "string"
       },
-      "media": {
-        "type": "array",
-        "items": {
-          "type": "string",
-          "format": "uri"
-        }
-      },
+       "media": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+              "photo": {
+                  "type": "array",
+                  "additionalItems": true,
+                  "items": {
+                      "anyOf": [
+                          {
+                              "type": "string",
+                              "format": "uri"
+                          }
+                      ]
+                  }
+              },
+              "video": {
+                  "type": "array",
+                  "additionalItems": true,
+                  "items": {
+                      "anyOf": [
+                          {
+                              "type": "string",
+                              "format": "uri"
+                          }
+                      ]
+                  }
+              }
+          }
+      },   
       "relatedTerms": {
         "type": "array",
         "items": {


### PR DESCRIPTION
Allow for listing Video and Photo separately to accommodate for difference in required elements used when rendering on site (`img` vs `embed`). Samples added for testing. 