### PR TITLE
Add DLB - Disney Live Action - Update studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -729,6 +729,11 @@
     "url": "https://www.ledock.ca"
   },
   {
+    "code": "DLA",
+    "description": "Disney Live Action",
+    "url": "https://en.wikipedia.org/wiki/Walt_Disney_Pictures"
+  },
+  {
     "code": "DLB",
     "description": "Dolby Laboratories"
   },


### PR DESCRIPTION
Opt OUT

Have requested from contact if they really want to use the URL of a Wiki page. Will also ask why Disney has 3 entries? DI, DLA and WDAS.