### PR TITLE
add Meänkieli

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -1957,6 +1957,15 @@
     ]
   },
   {
+    "dcncLanguage": "Meankieli",
+    "dcncTag": "FIT",
+    "rfc5646Tag": "fit",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Mohawk",
     "dcncTag": "MOH",
     "rfc5646Tag": "moh",


### PR DESCRIPTION
 - closes #885

Note, we should probably update schema to allow for accent characters in `dcncLanguage`