### PR TITLE
Update SIM Entry in facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -5866,7 +5866,7 @@
   },
   {
     "code": "SIM",
-    "description": "SIMPLE DCP"
+    "description": "Simple DCP"
   },
   {
     "code": "SKL",


### PR DESCRIPTION
Per email asked to change from all caps their facility name.

"Please change our name in your database using title case, as such:

Simple DCP

That way, the auto-completion in our packaging software will be correct at the outset, saving us the step of having to manually correct it every time."