### PR TITLE
Update references to DCI's HDR Addendum

### DIFF
--- a/src/main/data/contentmodifiers.json
+++ b/src/main/data/contentmodifiers.json
@@ -219,8 +219,8 @@
     "cplMetadata": {
       "definingDocs": [
         {
-          "name": "DCI High Dynamic Range D-Cinema Addendum, Version 1.1",
-          "url": "https://documents.dcimovies.com/HDR-Addendum/21e54ee3c65987ce09d692cfef791e19bf103d91/"
+          "name": "DCI High Dynamic Range D-Cinema Addendum, Version 1.2.1",
+          "url": "https://documents.dcimovies.com/HDR-Addendum/release/1.2.1/"
         }
       ],
       "element": "ExtensionMetadata",

--- a/src/main/data/cplmetadataexts.json
+++ b/src/main/data/cplmetadataexts.json
@@ -73,8 +73,8 @@
   {
     "definingDocs": [
       {
-        "name": "DCI High Dynamic Range D-Cinema Addendum, Version 1.1",
-        "url": "https://documents.dcimovies.com/HDR-Addendum/21e54ee3c65987ce09d692cfef791e19bf103d91/"
+        "name": "DCI High Dynamic Range D-Cinema Addendum, Version 1.2.1",
+        "url": "https://documents.dcimovies.com/HDR-Addendum/release/1.2.1/"
       }
     ],
     "description": "DCI HDR",


### PR DESCRIPTION
The latest HDR Addendum can now be found here:

https://documents.dcimovies.com/HDR-Addendum/release/1.2.1/
