### PR TITLE
Remove `ajp` language

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -104,15 +104,6 @@
     ]
   },
   {
-    "dcncLanguage": "Arabic - Jordan",
-    "dcncTag": "AJP",
-    "rfc5646Tag": "ajp",
-    "use": [
-      "audio",
-      "text"
-    ]
-  },
-  {
     "dcncLanguage": "Arabic - Kuwait",
     "dcncTag": "ABK",
     "rfc5646Tag": "afb-KW",


### PR DESCRIPTION
Closes #1293, see https://iso639-3.sil.org/request/2022-006. 

Use `apc` instead. 