### PR TITLE
Backfill 2026-06-08

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -2080,7 +2080,7 @@
   {
     "code": "DE0",
     "contact": {
-      "address": "01219 Dresden, Teplitzer Str. 43b, Germany",
+      "address": "Teplitzer Str. 43b, 01219 Dresden, Germany",
       "email": "info@schmalfilm-ueberspielen.de",
       "name": "Kazimirs"
     },
@@ -3338,7 +3338,7 @@
   {
     "code": "FUB",
     "contact": {
-      "address": "Marlene-Dietrich-Allee 11, D-14482 Potsdam-Babelsberg, Germany",
+      "address": "Marlene-Dietrich-Allee 11, 14482 Potsdam-Babelsberg, Germany",
       "email": "h.schoenherr@filmuniversitaet.de",
       "name": "Hagen Schoenherr"
     },
@@ -8032,7 +8032,7 @@
   {
     "code": "VCB1",
     "contact": {
-      "address": "Rua Horacio Vergueiro Rudge, 445 1.st, Casa Verde, 02512-060 Sao Paulo, SP, Brazil",
+      "address": "Rua Horácio Vergueiro Rudge, 445 1.st, Casa Verde, 02512-060 São Paulo, SP, Brazil",
       "email": "videcom@videcom.com.br",
       "name": "Mr. Alberto Baumstein"
     },

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -923,6 +923,16 @@
     "url": "http://www.bluepost.com.au"
   },
   {
+    "code": "BPS",
+    "contact": {
+      "address": "Level 3, 19 Harris Street, Pyrmont, NSW 2009, Australia",
+      "email": "joel.plunkett@bluepost.com.au",
+      "name": "Joel Plunkett"
+    },
+    "description": "Blue Post Sydney",
+    "url": "https://bluepost.com.au/"
+  },
+  {
     "code": "BPW",
     "contact": {
       "address": "66/67 Oshiwara Link Plaza, New Link Road Ext, Oshiwara, Jogeshwari West, Mumbai, MH 400102, India",
@@ -2068,6 +2078,16 @@
     "url": "https://www.digital-emulsion.com"
   },
   {
+    "code": "DE0",
+    "contact": {
+      "address": "01219 Dresden, Teplitzer Str. 43b, Germany",
+      "email": "info@schmalfilm-ueberspielen.de",
+      "name": "Kazimirs"
+    },
+    "description": "Schmalfilm - Video - und Dia DigitalisierungsService",
+    "url": "https://schmalfilm-ueberspielen.de"
+  },
+  {
     "code": "DE1",
     "contact": {
       "address": "Carrera 40C #12-95, Cali, Colombia",
@@ -2982,6 +3002,11 @@
     "url": "https://farmpost.tv"
   },
   {
+    "code": "FAST",
+    "description": "farbstudio GmbH",
+    "url": "https://farbstudio.de/"
+  },
+  {
     "code": "FAT",
     "description": "FATS Digital"
   },
@@ -3584,6 +3609,11 @@
   },
   {
     "code": "GUMP",
+    "contact": {
+      "address": "8 Boulevard de Ménilmontant, Impasse du Pilier, 75020 Paris, France",
+      "email": "a.leroux@gump.tv",
+      "name": "Antonin Le Roux"
+    },
     "description": "Gump Post-Production",
     "url": "https://www.gump.tv"
   },
@@ -8208,6 +8238,16 @@
     "url": "https://wagprodco.com"
   },
   {
+    "code": "WAL",
+    "contact": {
+      "address": "Aschebergsgatan 23A, 41127 Gothenburg, Sweden",
+      "email": "nikolai@waldmanmedia.com",
+      "name": "Nikolai Waldman"
+    },
+    "description": "Waldman Media",
+    "url": "https://waldmanmedia.com"
+  },
+  {
     "code": "WAN",
     "contact": {
       "address": "calle Serrano, 98 3º exterior derecha, Madrid, Spain",
@@ -8405,6 +8445,11 @@
     "code": "XVS",
     "description": "Axel Vasquez Studios",
     "url": "https://axelvasquez.com"
+  },
+  {
+    "code": "XXI",
+    "description": "Cinema XXI Content Quality Control",
+    "url": "https://www.cinema21.co.id/"
   },
   {
     "code": "XXL",

--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -41,6 +41,16 @@
     "url": "https://www.25-7.nl"
   },
   {
+    "code": "29P",
+    "contact": {
+      "address": "86-90, Paul Street, London EC2A 4NE, United Kingdom",
+      "email": "ebussi@twentyninepalmsent.com",
+      "name": "Edoardo Bussi"
+    },
+    "description": "Twenty-Nine Palms Entertainment - Production and distribution",
+    "url": "https://www.twentyninepalmsent.com"
+  },
+  {
     "code": "36F",
     "description": "36 FILMS",
     "url": "https://www.36films.fr"
@@ -640,6 +650,16 @@
     "url": "https://www.brightfish.be"
   },
   {
+    "code": "BFOX",
+    "contact": {
+      "address": "1801 Century Park East, Suite 450, Los Angeles, CA 90067, USA",
+      "email": "will@bluefoxentertainment.com",
+      "name": "Will Weissman"
+    },
+    "description": "Blue Fox Entertainment",
+    "url": "https://www.bluefoxentertainment.com"
+  },
+  {
     "code": "BFP",
     "contact": {
       "address": "Calle Luis Guillermo Villegas Blanco, Santa Eduvigis, Caracas 1071, Distrito Capital, Venezuela",
@@ -904,6 +924,16 @@
     },
     "description": "Conformity Post",
     "url": "https://sites.google.com/conformitypost.com/contact/home"
+  },
+  {
+    "code": "CFR",
+    "contact": {
+      "address": "18 Rue Jean-Baptiste Pigalle, 75009 Paris, France",
+      "email": "antoinepostprod@gmail.com",
+      "name": "Antoine Lepoivre"
+    },
+    "description": "Cinéfrance Studios",
+    "url": "https://cinefrancestudios.eu"
   },
   {
     "code": "CFSL",
@@ -1991,6 +2021,16 @@
     "url": "https://www.goldentouchfilm.com"
   },
   {
+    "code": "GUMP",
+    "contact": {
+      "address": "8 Boulevard de Ménilmontant, Impasse du Pilier, 75020 Paris, France",
+      "email": "a.leroux@gump.tv",
+      "name": "Antonin Le Roux"
+    },
+    "description": "Gump Post-Production",
+    "url": "https://www.gump.tv"
+  },
+  {
     "code": "GYF",
     "contact": {
       "address": "Building 2, No. 6 Chaoyang Park South Road, Chaoyang District, Beijing 100026, China",
@@ -2432,6 +2472,16 @@
     "url": "https://kfilmsmorocco.com/"
   },
   {
+    "code": "KFM",
+    "contact": {
+      "address": "C/ Olivo 14, Entreplanta, 28023 Madrid, Spain",
+      "email": "marta.barrios@keyframe.es",
+      "name": "Mrs Marta Barrios"
+    },
+    "description": "Keyframe Servicios Audiovisuales",
+    "url": "https://audiovisual.keyframe.es/"
+  },
+  {
     "code": "KHH",
     "description": "Kinemathek Hamburg"
   },
@@ -2614,6 +2664,16 @@
   {
     "code": "LSR",
     "description": "LASERFILM CINE Y VÍDEO, SL"
+  },
+  {
+    "code": "LUC",
+    "contact": {
+      "address": "Calle Príncipe 12, 6A - 28012 Madrid, Spain",
+      "email": "noemie@luciernagacolor.com",
+      "name": "Noémie Dulau"
+    },
+    "description": "LUCIERNAGA Color Grading",
+    "url": "https://luciernagacolor.com"
   },
   {
     "code": "LUP",
@@ -3296,6 +3356,16 @@
   {
     "code": "PAT",
     "description": "PATHE DISTRIBUTION"
+  },
+  {
+    "code": "PBS",
+    "contact": {
+      "address": "1101, Amalfi, Raheja Exotica, Pascal Wadi, Madh, Malad, Mumbai, Maharashtra, India",
+      "email": "contact@tanujbhatiafilms.com",
+      "name": "Mr. Tanuj"
+    },
+    "description": "Punit Balan Studios",
+    "url": "https://punitbalangroup.com"
   },
   {
     "code": "PC",

--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -43,7 +43,7 @@
   {
     "code": "29P",
     "contact": {
-      "address": "86-90, Paul Street, London EC2A 4NE, United Kingdom",
+      "address": "86-90 Paul Street, London EC2A 4NE, United Kingdom",
       "email": "ebussi@twentyninepalmsent.com",
       "name": "Edoardo Bussi"
     },
@@ -2673,7 +2673,7 @@
   {
     "code": "LUC",
     "contact": {
-      "address": "Calle Príncipe 12, 6A - 28012 Madrid, Spain",
+      "address": "Calle del Príncipe 12, 6A, 28012 Madrid, Spain",
       "email": "noemie@luciernagacolor.com",
       "name": "Noémie Dulau"
     },
@@ -3365,7 +3365,7 @@
   {
     "code": "PBS",
     "contact": {
-      "address": "1101, Amalfi, Raheja Exotica, Pascal Wadi, Madh, Malad, Mumbai, Maharashtra, India",
+      "address": "Flat 1101, Amalfi, Raheja Exotica, Pascal Wadi, Madh Island, Malad West, Mumbai 400061, Maharashtra, India",
       "email": "contact@tanujbhatiafilms.com",
       "name": "Mr. Tanuj"
     },

--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -2633,6 +2633,11 @@
     "url": "https://laika.com"
   },
   {
+    "code": "LMNA",
+    "description": "Lucas Museum of Narrative Art",
+    "url": "https://lucasmuseum.org/"
+  },
+  {
     "code": "LN36",
     "description": "LINE 36 STUDIO"
   },


### PR DESCRIPTION
Add Studios/Facilities, including one manual request. 

## studios.json

**Added:**
- `29P` Twenty-Nine Palms Entertainment - Production and distribution
- `BFOX` Blue Fox Entertainment
- `CFR` Cinéfrance Studios
- `GUMP` Gump Post-Production
- `KFM` Keyframe Servicios Audiovisuales
- `LMNA` Lucas Museum of Narrative Art (closes #1319)
- `LUC` LUCIERNAGA Color Grading
- `PBS` Punit Balan Studios

## facilities.json

**Added:**
- `BPS` Blue Post Sydney (separate Sydney entry; existing `BPM` covers Blue Post Australia)
- `DE0` Schmalfilm - Video - und Dia DigitalisierungsService
- `FAST` farbstudio GmbH (opt-out — no contact)
- `WAL` Waldman Media
- `XXI` Cinema XXI Content Quality Control (opt-out — no contact)

**Updated:**
- `GUMP` Gump Post-Production — contact added

## Address normalization

- `DE0` reordered to street-first (Deutsche Post convention)
- `LUC` corrected to `Calle del Príncipe`; replaced dash with comma 
- `PBS` added PIN `400061`, `Flat` prefix, `Madh Island`, `Malad West`
- `29P` dropped non-standard comma in `86-90 Paul Street`
- Added missing country suffixes where omitted (UK, France, Canada, Australia)