### PR TITLE
Add GFH - Gun For Hire - facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -3474,6 +3474,16 @@
     "description": "Global Film Factory"
   },
   {
+    "code": "GFH",
+    "contact": {
+      "address": "910 East 68th Street, Inglewood, CA 90302, USA",
+      "email": "rolandcdiaz@gmail.com",
+      "name": "Roland Diaz"
+    },
+    "description": "Gun For Hire",
+    "url": "https://gunforhire.us"
+  },
+  {
     "code": "GFP",
     "contact": {
       "address": "6 Chao-utid Rd., Baan Pong, Ratchaburi 70110, THAILAND",


### PR DESCRIPTION
Processes #1342 (Google Form submission — `facilities` / `form-submission`).

Adds facility code **GFH** — Gun For Hire (https://gunforhire.us), a production-services company in Inglewood, CA.

**Normalization applied to the submitted address:**
- `910 East 68th Street Inglewood, ca 90302` → `910 East 68th Street, Inglewood, CA 90302, USA` (comma after street, `ca`→`CA`, country suffix). ZIP 90302 verified against Redfin/Trulia.

Canonicalized and validated locally. URL Safe Browsing check confirmed clean for `gunforhire.us` via direct API call.

closes #1342