### PR TITLE
Add YPS - YUMA PILATES STUDIO (obsoletes YSP) - facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -8526,6 +8526,16 @@
     "description": "YELLOWMOON POST PRODUCTION"
   },
   {
+    "code": "YPS",
+    "contact": {
+      "address": "15 rue du Dauphiné, 69800 Saint-Priest, France",
+      "email": "juliediazprod@gmail.com",
+      "name": "MRS JULIE DIAZ"
+    },
+    "description": "YUMA PILATES STUDIO",
+    "url": "https://yumastudiopilates.com"
+  },
+  {
     "code": "YSI",
     "contact": {
       "address": "Wega 25, 2221ND Katwijk, The Netherlands",
@@ -8534,6 +8544,14 @@
     },
     "description": "YAVUZ SELIM ISLER",
     "url": "https://yavuzselimisler.com"
+  },
+  {
+    "code": "YSP",
+    "description": "YUMA STUDIO PILATES",
+    "obsolete": true,
+    "obsoletedBy": [
+      "YPS"
+    ]
   },
   {
     "code": "YSS",


### PR DESCRIPTION
Processes #1340 (Google Form submission — `facilities` / `form-submission`).

Applies both entries from the submission's JSON block:
- Adds facility code **YPS** — YUMA PILATES STUDIO (https://yumastudiopilates.com).
- Marks **YSP** (YUMA STUDIO PILATES) `obsolete: true`, `obsoletedBy: ["YPS"]`.

Note: the issue's `> NOTE:` flagged that `YSP` was not previously present in `facilities.json` (confirmed via history). The obsolete tombstone is added per the submission so the prior code is recorded and reserved.

**Normalization applied to the submitted address:**
- `15 rue du Dauphiné, 69800 St Priest` → `15 rue du Dauphiné, 69800 Saint-Priest, France` (expand commune name `St Priest`→`Saint-Priest`, append country). Street verified in Saint-Priest (69800).

Canonicalized and validated locally. URL Safe Browsing check confirmed clean for `yumastudiopilates.com` via direct API call.

closes #1340