### PR TITLE
Add Language - Mi'kmaq (Micmac)

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -1957,6 +1957,18 @@
     ]
   },
   {
+    "comments": [
+      "Mi'kmaq"
+    ],
+    "dcncLanguage": "Micmac",
+    "dcncTag": "MIC",
+    "rfc5646Tag": "mic",
+    "use": [
+      "audio",
+      "text"
+    ]
+  },
+  {
     "dcncLanguage": "Mohawk",
     "dcncTag": "MOH",
     "rfc5646Tag": "moh",


### PR DESCRIPTION
Processes #1345. Adds the Mi'kmaq language to `languages.json`, per the IANA language-subtag registry (subtag `mic`).

```json
{
  "comments": ["Mi'kmaq"],
  "dcncLanguage": "Micmac",
  "dcncTag": "MIC",
  "rfc5646Tag": "mic",
  "use": ["audio", "text"]
}
```

**Field decisions:**
- `rfc5646Tag: "mic"` — the IANA/ISO 639-2/3 subtag (no ISO 639-1 two-letter code exists for this language).
- `dcncTag: "MIC"` — uppercased subtag, matching how other 3-letter languages are tagged here (e.g. Cherokee `chr`→`CHR`, Mohawk `moh`→`MOH`, Arapaho `arp`→`ARP`). Confirmed `MIC` is not already in use.
- `dcncLanguage: "Micmac"` — the schema's `dcncLanguage` pattern (`^[A-Za-z -]{1,}$`) disallows the apostrophe, so the apostrophe-free IANA description is used. The preferred spelling **Mi'kmaq** is preserved in `comments`.
- `use: ["audio", "text"]` — spoken language (default; `sign` reserved for sign languages).

Canonicalized and validated locally; sorts alphabetically between Meankieli and Mohawk.

closes #1345
