### PR TITLE
Add Language - Spanish Sign Language

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -2762,6 +2762,13 @@
     ]
   },
   {
+    "dcncLanguage": "Spanish Sign Language",
+    "rfc5646Tag": "ssp",
+    "use": [
+      "sign"
+    ]
+  },
+  {
     "dcncLanguage": "Swahili",
     "dcncTag": "SW",
     "rfc5646Tag": "sw",


### PR DESCRIPTION
Processes #1275. Adds Spanish Sign Language to `languages.json`, per the IANA language-subtag registry (subtag `ssp`).

```json
{
  "dcncLanguage": "Spanish Sign Language",
  "rfc5646Tag": "ssp",
  "use": ["sign"]
}
```

**Field decisions:**
- Verified against the live IANA registry (File-Date 2026-05-05): `Type: language`, `Subtag: ssp`, `Description: Spanish Sign Language`, `Added: 2009-07-29`. Not deprecated; the standalone `ssp` is the preferred form (the `sgn-ssp` extlang carries `Preferred-Value: ssp`).
- `use: ["sign"]` — sign language.
- **No `dcncTag`**, matching the existing sign-language entries (American Sign Language `ase`, Brazilian Sign Language `bzs`), which carry only `dcncLanguage` + `rfc5646Tag` + `use`.

Canonicalized and validated locally; sorts alphabetically between Spanish - Venezuela and Swahili.

closes #1275
