### PR TITLE
Add Qube Cinema EPIQ registry entries and fix related schema validation

### DIFF
--- a/src/main/data/contentmodifiers.json
+++ b/src/main/data/contentmodifiers.json
@@ -243,5 +243,22 @@
     "dcncCode": "EC",
     "dcncSortOrder": 14,
     "description": "Eclaircolor graded image."
-  }
+  },
+  {
+    "cplMetadata": {
+      "definingDocs": [
+        {
+          "name": "ISDCF CPL Metadata Extensions",
+          "url": "https://www.isdcf.com/site/registry-cpl-extensions/"
+        }
+      ],
+      "element": "ExtensionMetadata",
+      "extName": "EPIQ",
+      "extScope": "http://www.qubecinema.com/schemas/2025/EPIQ-Metadata",
+      "metaType": "Extension Present"
+    },
+    "dcncCode": "EPIQ",
+    "dcncSortOrder": 15,
+    "description": "EPIQ Premium Large Format"
+}
 ]

--- a/src/main/data/cplmetadataexts.json
+++ b/src/main/data/cplmetadataexts.json
@@ -84,5 +84,13 @@
       "extpropName": "EOTF",
       "extpropValue": "ST 2084"
     }
+  },
+  {
+    "contact": "https://www.qubecinema.com/contactus",
+    "description": "EPIQ Premium Large Format",
+    "extension": {
+      "extName": "EPIQ",
+      "extScope": "http://www.qubecinema.com/schemas/2025/EPIQ-Metadata"
+    }
   }
 ]

--- a/src/main/schemas/cplmetadataexts.schema.json
+++ b/src/main/schemas/cplmetadataexts.schema.json
@@ -21,7 +21,7 @@
               "type": "string"
           }
       },
-      "required": [ "extName", "extScope", "extpropName", "extpropValue"]
+      "required": [ "extName", "extScope"]
     }
   },
   "type": "array",


### PR DESCRIPTION
Adds Qube Cinema EPIQ to the Metadata Registry to close #1354.

Content Modifier: `EPIQ`

Metadata Extension:
```xml
<cpl-meta:ExtensionMetadata scope=http://www.qubecinema.com/schemas/2025/EPIQ-Metadata>
  <cpl-meta:Name>EPIQ</cpl-meta:Name>
</cpl-meta:ExtensionMetadata>
```

This Metadata Extension does not implement any optional Properties, and it is valid as per `ST 429-16` schema.
The PR includes a fix for `cplmetadataexts.schema.json` as it presently requires Property Name/Value pairs.