### PR TITLE
Add EUT - Eutopiafilm - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -1531,6 +1531,16 @@
     "url": "https://www.espritfilm.co.uk"
   },
   {
+    "code": "EUT",
+    "contact": {
+      "address": "EUTOPIAFILM GmbH, Claudiastraße 8, 6020 Innsbruck, Austria",
+      "email": "office@eutopia.film",
+      "name": "Bernhard Holzhammer"
+    },
+    "description": "Eutopiafilm",
+    "url": "https://www.eutopia.film/"
+  },
+  {
     "code": "EVDN",
     "description": "Erik van der Neut",
     "url": "https://looknohands.com/"


### PR DESCRIPTION
Processes #1361 (Google Form submission — `studios` / `form-submission`).

Adds studio code **EUT** — Eutopiafilm (https://www.eutopia.film/), a documentary/feature production company in Innsbruck, Austria.

**Normalization applied to the submitted address:**
- `…, AUSTRIA` → `…, Austria` (title-cased country suffix). Otherwise as submitted.
- Address verified: Claudiastraße 8, 6020 Innsbruck is Eutopiafilm GmbH's registered HQ; founder Bernhard Holzhammer matches the submitted contact.

Canonicalized and validated locally.

closes #1361
