### PR TITLE
Add TRF - Terrier Films - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -4361,6 +4361,16 @@
     "description": "Trench Enertainment"
   },
   {
+    "code": "TRF",
+    "contact": {
+      "address": "Fernando 88 - 104, Colonia Álamos, C.P. 03400, Benito Juárez, Mexico City, México",
+      "email": "rodrigo@terrierfilms.com",
+      "name": "Rodrigo Hernández Cruz"
+    },
+    "description": "Terrier Films",
+    "url": "https://www.terrierfilms.com"
+  },
+  {
     "code": "TRIG",
     "description": "TRIGON-FILM"
   },


### PR DESCRIPTION
Processes #1359 (Google Form submission — `studios` / `form-submission`).

Adds studio code **TRF** — Terrier Films (https://www.terrierfilms.com), a production company in Mexico City.

**Deviation from the submitted JSON block — treated as an add, not an update/obsolete:**
The form was filled as "Update existing" with `TRF` obsoleting `TRF` (`obsoletedBy: ["TRF"]`). The issue's own `> NOTE:` lines flag that `TRF` was not found in `studios.json` (confirmed). A code cannot obsolete itself, and the array would have produced a duplicate `TRF` that fails validation. Since `TRF` doesn't yet exist, this is simply a new entry — added once, with no obsolete tombstone.

**Normalization applied to the submitted address:**
- `Fernando 88 - 104, cp 03400, Colonia Álamos, Benito Juárez, Mexico City, México` → `Fernando 88 - 104, Colonia Álamos, C.P. 03400, Benito Juárez, Mexico City, México` (postcode moved to the standard Mexican position after the colonia; `cp`→`C.P.`).
- Verified: C.P. 03400 / Colonia Álamos / Benito Juárez / CDMX is a valid postal envelope.

Canonicalized and validated locally.

closes #1359
