### PR TITLE
Add SUPE - Supermouche Productions - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -4159,6 +4159,16 @@
     "url": "https://sites.google.com/view/k-number/?fbclid=PAZXh0bgNhZW0CMTEAAaaIZ6Cmbps4Bha7yHeKZAxVX2t_B5nLFl_ts8iXXyWMpPbvHM0wIA5-zQM_aem_y8aEp1902R9VCAbCWuZoRg"
   },
   {
+    "code": "SUPE",
+    "contact": {
+      "address": "2 Rue de Nancy, 88000 Épinal, France",
+      "email": "info@supermouche.fr",
+      "name": "Mr. Georges"
+    },
+    "description": "Supermouche Productions",
+    "url": "https://supermouche.fr/"
+  },
+  {
     "code": "SVM",
     "contact": {
       "address": "245 Kenneth Dr, Ste. 400, Rochester, NY 14623, USA",


### PR DESCRIPTION
Processes #1358 (Google Form submission — `studios` / `form-submission`).

Adds studio code **SUPE** — Supermouche Productions (https://supermouche.fr/), an audiovisual production company in Épinal, France.

**Code changed from SUMO → SUPE** per the requester's follow-up ([comment](https://github.com/ISDCF/registries/issues/1358#issuecomment-4753614367)): they asked for `SUPE` instead of the originally-submitted `SUMO` for better consistency with the company name. Confirmed `SUPE` is not already in use.

**Normalization applied to the submitted address:**
- `2 Rue de Nancy, 88000 Épinal` → `2 Rue de Nancy, 88000 Épinal, France` (appended mandatory country suffix).
- Verified: 2 Rue de Nancy, 88000 Épinal is Supermouche Productions' registered address.

Canonicalized and validated locally.

closes #1358
