### PR TITLE
Update SEA - Visitant Media - facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -6910,12 +6910,12 @@
   {
     "code": "SEA",
     "contact": {
-      "address": "950 E 3rd St., Los Angeles, CA 90013, USA",
-      "email": "andrew@sayonse.com",
-      "name": "Andrew Saulf"
+      "address": "509 Work St, Montebello, CA 90640, USA",
+      "email": "andrew@visitantmedia.com",
+      "name": "Andrew Såulf, CSI"
     },
-    "description": "Sayonse",
-    "url": "https://www.sayonse.com"
+    "description": "Visitant Media",
+    "url": "https://www.visitantmedia.com"
   },
   {
     "code": "SEK",


### PR DESCRIPTION
Processes #1357 (Google Form submission — `facilities` / `form-submission`).

Updates existing facility code **SEA** — the same contact (Andrew Saulf) has rebranded from **Sayonse** to **Visitant Media**, with a new address, email, and website. All fields refreshed per the submission:

| field | before | after |
|---|---|---|
| description | Sayonse | Visitant Media |
| url | https://www.sayonse.com | https://www.visitantmedia.com |
| email | andrew@sayonse.com | andrew@visitantmedia.com |
| name | Andrew Saulf | Andrew Såulf, CSI |
| address | 950 E 3rd St., Los Angeles, CA 90013, USA | 509 Work St, Montebello, CA 90640, USA |

**Notes:**
- Same individual (Andrew Saulf) — confirmed this is an update of the existing entry, not a new code.
- Name kept as submitted, including the `å` in "Såulf" and the "CSI" suffix (the prior entry had plain "Saulf" — flagging in case the diacritic is unintended).
- Address normalized: `509 Work St. Montebello CA 90640` → `509 Work St, Montebello, CA 90640, USA` (comma separators + country suffix). Verified as a real Montebello, CA address.

Canonicalized and validated locally.

closes #1357
