### PR TITLE
Add CPXM - Cineplex Media - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -1094,6 +1094,16 @@
     "description": "CURRENT PICTURES"
   },
   {
+    "code": "CPXM",
+    "contact": {
+      "address": "352 Rue Émery, Montréal, QC H2X 1J2, Canada",
+      "email": "nicolas.mifsud@bydeluxe.com",
+      "name": "Mrs Charlene Ham"
+    },
+    "description": "Cineplex Media",
+    "url": "https://media.cineplex.com/"
+  },
+  {
     "code": "CRL",
     "contact": {
       "address": "1 N. College St, Northfield, MN 55057, USA",


### PR DESCRIPTION
Processes #1353 (Google Form submission — `studios` / `form-submission`).

Adds studio code **CPXM** — Cineplex Media (https://media.cineplex.com/).

**Address:** `352 Rue Émery, Montréal, QC H2X 1J2, Canada` — already well-formed; no normalization needed. Verified as Cineplex's Montréal Regional Office.

**Note:** the submitted contact email (`nicolas.mifsud@bydeluxe.com`) is on a different domain than the company website; kept as submitted (opted-in contact).

Canonicalized and validated locally.

closes #1353
