### PR TITLE
Fix typo in "Australia"

### DIFF
--- a/src/main/data/languages.json
+++ b/src/main/data/languages.json
@@ -947,7 +947,7 @@
     ]
   },
   {
-    "dcncLanguage": "English - Austrialia",
+    "dcncLanguage": "English - Australia",
     "dcncTag": "EAU",
     "rfc5646Tag": "en-AU",
     "use": [


### PR DESCRIPTION
"Australia" was spelled wrong.