### PR TITLE
Add PATP - Paterson-Pictures AG - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -3383,6 +3383,16 @@
     "description": "PATHE DISTRIBUTION"
   },
   {
+    "code": "PATP",
+    "contact": {
+      "address": "Dufourstrasse 24, 8008 Zürich, Switzerland",
+      "email": "matthias.keller@paterson-pictures.ch",
+      "name": "Matthias Keller"
+    },
+    "description": "Paterson-Pictures AG",
+    "url": "https://www.paterson-pictures.ch"
+  },
+  {
     "code": "PBS",
     "contact": {
       "address": "Flat 1101, Amalfi, Raheja Exotica, Pascal Wadi, Madh Island, Malad West, Mumbai 400061, Maharashtra, India",


### PR DESCRIPTION
Processes #1369 (Google Form submission — `studios` / `form-submission`).

Adds studio code **PATP** — Paterson-Pictures AG (https://www.paterson-pictures.ch), a film/video production company in Zürich.

**Normalization applied to the submitted address:**
- `Dufourstrasse 24, Zürich, 8008, Switzerland` → `Dufourstrasse 24, 8008 Zürich, Switzerland` (Swiss convention: postcode before city).
- Verified: Dufourstrasse 24, 8008 Zürich, director Matthias Keller (matches the submitted contact).

Canonicalized and validated locally.

closes #1369
