### PR TITLE
Add LCF - LIGHTCUT FILM - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -2572,6 +2572,11 @@
     "url": "https://www.laboratoriocisco.org/"
   },
   {
+    "code": "LCF",
+    "description": "LIGHTCUT FILM",
+    "url": "https://www.lightcutfilm.com/"
+  },
+  {
     "code": "LCL",
     "description": "LORENZO Colorlab",
     "url": "https://www.lorenzocolorlab.com"


### PR DESCRIPTION
Processes #1370 and #1371 (Google Form submissions — `studios` / `form-submission`).

Adds studio code **LCF** — **LIGHTCUT FILM** (https://www.lightcutfilm.com/). Submitter opted out of public contact listing, so `code` + `description` + `url` only.

**Consolidates two issues for the same code:**
- #1370 submitted `LCF` as an add with description `LABORATORIO DI POSTPRODUZIONE`.
- #1371 followed up (form request-type "Update") with description `LIGHTCUT FILM`.

`LCF` did not previously exist, and only one entry per code is possible, so this adds `LCF` once using the later, company-name description **LIGHTCUT FILM** (matches the `lightcutfilm.com` domain).

Canonicalized and validated locally.

closes #1370
closes #1371
