### PR TITLE
Update CPXM - Cineplex Media - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -1097,7 +1097,7 @@
     "code": "CPXM",
     "contact": {
       "address": "352 Rue Émery, Montréal, QC H2X 1J2, Canada",
-      "email": "nicolas.mifsud@bydeluxe.com",
+      "email": "Charlene.Ham@cineplex.com",
       "name": "Mrs Charlene Ham"
     },
     "description": "Cineplex Media",


### PR DESCRIPTION
Processes #1372 (Google Form submission — `studios` / `form-submission`).

Updates existing studio code **CPXM** — Cineplex Media. Corrects the contact email to the proper Cineplex address matching the contact person:
- email: `nicolas.mifsud@bydeluxe.com` → `Charlene.Ham@cineplex.com`

This resolves the domain mismatch flagged when `CPXM` was first added (#1353). The accented `Rue Émery` and existing URL are retained; email is the only change.

Canonicalized and validated locally.

closes #1372
