### PR TITLE
Add UTV - Unveil Studios - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -4544,6 +4544,11 @@
     "description": "Utopia"
   },
   {
+    "code": "UTV",
+    "description": "Unveil Studios",
+    "url": "https://unveiltv.com/"
+  },
+  {
     "code": "VAR",
     "contact": {
       "address": "16 Park Ave #303, Rutherford, NJ 07070, USA",


### PR DESCRIPTION
Processes #1386 (Google Form submission — `studios` / `form-submission`).

Adds studio code **UTV** — Unveil Studios (https://unveiltv.com/). Submitter opted out of public contact listing, so `code` + `description` + `url` only.

Canonicalized and validated locally.

closes #1386