### PR TITLE
Add FCZ - Filmcoopi Zürich AG - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -1634,6 +1634,11 @@
     "url": "https://www.facebook.com/FilmcandoPro"
   },
   {
+    "code": "FCZ",
+    "description": "Filmcoopi Zürich AG",
+    "url": "https://filmcoopi.ch/"
+  },
+  {
     "code": "FDP",
     "description": "Flor de Papel",
     "url": "https://www.instagram.com/flordepapelcine"


### PR DESCRIPTION
Processes #1389 (Google Form submission — `studios` / `form-submission`).

Adds studio code **FCZ** — Filmcoopi Zürich AG (https://filmcoopi.ch/). Submitter opted out of public contact listing, so `code` + `description` + `url` only.

Canonicalized and validated locally.

closes #1389