### PR TITLE
Add LNRF - LNR Films - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -2672,6 +2672,11 @@
     "description": "LINE 36 STUDIO"
   },
   {
+    "code": "LNRF",
+    "description": "LNR Films",
+    "url": "https://www.lnrfilms.com"
+  },
+  {
     "code": "LOC",
     "description": "LOCOMOTIVE PRODUCTIONS (LATVIA)"
   },


### PR DESCRIPTION
Processes #1392 (Google Form submission — `studios` / `form-submission`).

Adds studio code **LNRF** — LNR Films (https://www.lnrfilms.com). Submitter opted out of public contact listing, so `code` + `description` + `url` only.

Canonicalized and validated locally.

closes #1392