### PR TITLE
Add WTC - Warner Bros. Water Tower Color (obsoletes MPI) - facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -5233,7 +5233,11 @@
   },
   {
     "code": "MPI",
-    "description": "WARNER BROS. MOTION PICTURE IMAGING"
+    "description": "WARNER BROS. MOTION PICTURE IMAGING",
+    "obsolete": true,
+    "obsoletedBy": [
+      "WTC"
+    ]
   },
   {
     "code": "MPL",
@@ -8439,6 +8443,11 @@
     "code": "WRK",
     "description": "The DCP Works",
     "url": "https://www.thedcpworks.com"
+  },
+  {
+    "code": "WTC",
+    "description": "Warner Bros. Water Tower Color",
+    "url": "https://watertowercolor.com"
   },
   {
     "code": "WTF",


### PR DESCRIPTION
Processes #1398 (Google Form submission — `facilities` / `form-submission`).

Adds facility code **WTC** — Warner Bros. Water Tower Color (https://watertowercolor.com), and marks **MPI** (WARNER BROS. MOTION PICTURE IMAGING) obsolete, `obsoletedBy: ["WTC"]`.

Note: the companion `studios.json` request for this same rename (#1396) was closed as erroneous — `MPI` was never a studio code, only a facility code — so this facility-registry change is the correct one.

Canonicalized and validated locally.

closes #1398