### PR TITLE
Add FOO - FooEngine - Update facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -3253,6 +3253,16 @@
     "description": "FOCUS ON DIGITAL"
   },
   {
+    "code": "FOO",
+    "contact": {
+      "address": "Wren House, Betsy Lane, Bransgore Christchurch, BH23 8AQ",
+      "email": "arran@fooengine.com",
+      "name": "Arran Corbett"
+    },
+    "description": "FooEngine",
+    "url": "https://www.fooengine.com"
+  },
+  {
     "code": "FOS",
     "contact": {
       "address": "38 rue Alexis Lepère, 93100 Montreuil, France",


### PR DESCRIPTION
Processes #1437 (Google Form submission — `facilities` / `form-submission`).

Adds facility code **FOO** — FooEngine (https://www.fooengine.com), with contact info provided by the submitter, who opted in to public listing.

⚠️ **Address flag for maintainer review**: the submitted address ("Wren House, Betsy Lane, Bransgore Christchurch, BH23 8AQ") matches FooEngine Limited's *former* UK Companies House registered office. Companies House currently lists the company's registered office as **27 Mortimer Street, London, W1T 3BL** (changed 2022-05-04). This could be a stale/personal address the submitter still uses operationally, or it could be outdated — worth a quick confirmation with the submitter (arran@fooengine.com) before merging. I've kept the address as submitted rather than substituting the registered-office address, since a company's registered office and its operating address commonly differ.

Canonicalized and validated locally.

closes #1437