### PR TITLE
Add CXL - Complexity Limited (obsoletes CMPX) - facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -1507,6 +1507,10 @@
   {
     "code": "CMPX",
     "description": "Complexity Limited",
+    "obsolete": true,
+    "obsoletedBy": [
+      "CXL"
+    ],
     "url": "https://www.complexityltd.uk/"
   },
   {
@@ -1836,6 +1840,11 @@
   {
     "code": "CXF",
     "description": "COMPLEXION FILMS"
+  },
+  {
+    "code": "CXL",
+    "description": "Complexity Limited",
+    "url": "https://complexityltd.uk/"
   },
   {
     "code": "CYM",


### PR DESCRIPTION
Processes #1438 (Google Form submission — `facilities` / `form-submission`).

Adds facility code **CXL** — Complexity Limited (https://complexityltd.uk/), and marks **CMPX** (Complexity Limited) obsolete, `obsoletedBy: ["CXL"]`. Submitter opted out of public contact listing.

Note: `studios.json` has a separate `CMPX` entry ("Complexity" — added in #1420) that is out of scope for this request, which only covers the `facilities.json` rename; left untouched.

Canonicalized and validated locally.

closes #1438