### PR TITLE
Add APAT (ApatLab) to studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -349,6 +349,11 @@
     "description": "ANNAPURNA PICTURES"
   },
   {
+    "code": "APAT",
+    "description": "ApatLab",
+    "url": "https://apatlab.com"
+  },
+  {
     "code": "APC",
     "description": "Aurora Picture Company",
     "url": "https://www.aurorapicturecompany.com"


### PR DESCRIPTION
## Summary
- Add studio entry `APAT` for ApatLab (https://apatlab.com) to `studios.json`, per submission request.
- Uses "ApatLab" casing to stay consistent with the companion facilities.json entry (#1452).

Closes #1449

## Test plan
- [x] `ISDCF_SKIP_URL_CHECK=1 npm run validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)