### PR TITLE
Add BLND - Blinds Creative - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -752,6 +752,11 @@
     "url": "https://www.blender.org/about/foundation/"
   },
   {
+    "code": "BLND",
+    "description": "Blinds Creative",
+    "url": "https://blindscreative.com/nl"
+  },
+  {
     "code": "BLNK",
     "description": "BLANKTAPE"
   },


### PR DESCRIPTION
Processes #1455 (Google Form submission — `studios` / `form-submission`).

Adds studio code **BLND** — Blinds Creative (https://blindscreative.com/nl). Submitter opted out of public contact listing, so `code` + `description` + `url` only.

Canonicalized and validated locally.

closes #1455

🤖 Generated with [Claude Code](https://claude.com/claude-code)