### PR TITLE
Add HDC - HomeDCP - facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -3778,6 +3778,16 @@
     "description": "Harvest Digital Agriculture"
   },
   {
+    "code": "HDC",
+    "contact": {
+      "address": "9, Sinchon 8-gil, Jocheon-eup, Jeju-si, Jeju-do, Republic of Korea",
+      "email": "kksan@naver.com",
+      "name": "Mr. Kim"
+    },
+    "description": "HomeDCP",
+    "url": "https://blog.naver.com/kksan"
+  },
+  {
     "code": "HDM",
     "description": "HDMG",
     "url": "https://hdmg.com"


### PR DESCRIPTION
Processes #1457 (Google Form submission — `facilities` / `form-submission`).

Adds facility code **HDC** — HomeDCP (https://blog.naver.com/kksan), with the contact info from the form submission.

Checked the mailing address against existing Korean-address entries in the registry (e.g. `733-24, Jiwol-ri, Chowol-eup, Gwangju-si, Gyeonggi-do, Republic of Korea`) — the submitted `9, Sinchon 8-gil, Jocheon-eup, Jeju-si, Jeju-do, Republic of Korea` matches that convention exactly, so it's used as-is.

Canonicalized and validated locally.

closes #1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)