### PR TITLE
Add MNC - Media Network Corporation New Zealand - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -2991,6 +2991,15 @@
     "description": "MAGNA MANA PRODUCTION"
   },
   {
+    "code": "MNC",
+    "contact": {
+      "email": "studios@medianetwork.co.nz",
+      "name": "Ken Khan"
+    },
+    "description": "Media Network Corporation New Zealand",
+    "url": "https://www.medianetwork.co.nz"
+  },
+  {
     "code": "MNS",
     "contact": {
       "address": "Bd. Dinicu Golescu Nr.9, Et.1, Ap.1, Int.01, Sect.1, Bucharest, 010862, Romania",


### PR DESCRIPTION
Processes #1461 (Google Form submission — `studios` / `form-submission`).

Adds studio code **MNC** — Media Network Corporation New Zealand (https://www.medianetwork.co.nz).

Note: the form's "Address" field contained an email address (`ken@medianetwork.co.nz`) rather than a mailing address — clearly a data-entry mix-up, since the "Email" field already holds `studios@medianetwork.co.nz`. Omitted the bogus address rather than storing an email in the address field; `name` + `email` alone satisfy the schema.

Canonicalized and validated locally.

closes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)