### PR TITLE
Add MIST - Mist Postproduction - facilities.json

### DIFF
--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -5196,7 +5196,7 @@
     "contact": {
       "address": "12 rue charles porcher, 69009 Lyon, France",
       "email": "victor@mist-postproduction.com",
-      "name": "DAGAND Victor"
+      "name": "Victor Dagand"
     },
     "description": "Mist Postproduction",
     "url": "https://www.mist-postproduction.com/"

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -5194,7 +5194,7 @@
   {
     "code": "MIST",
     "contact": {
-      "address": "12 rue charles porcher, 69009 Lyon, France",
+      "address": "12 rue Charles Porcher, 69009 Lyon, France",
       "email": "victor@mist-postproduction.com",
       "name": "Victor Dagand"
     },

--- a/src/main/data/facilities.json
+++ b/src/main/data/facilities.json
@@ -5192,6 +5192,16 @@
     "description": "MISTIKA POST"
   },
   {
+    "code": "MIST",
+    "contact": {
+      "address": "12 rue charles porcher, 69009 Lyon, France",
+      "email": "victor@mist-postproduction.com",
+      "name": "DAGAND Victor"
+    },
+    "description": "Mist Postproduction",
+    "url": "https://www.mist-postproduction.com/"
+  },
+  {
     "code": "MJR",
     "contact": {
       "address": "4-31-1 Nakaochiai, Shinjuku-ku, Tokyo, Japan",


### PR DESCRIPTION
Processes #1462 (Google Form submission — `facilities` / `form-submission`).

Adds facility code **MIST** — Mist Postproduction (https://www.mist-postproduction.com/), with the contact info from the form submission.

Two cleanups vs. the raw submission:
- Description was submitted as `Mist Postproduction     Post production studio` (company name + generic descriptor run together with multiple spaces). Trimmed to just the company name, `Mist Postproduction`, matching the convention used elsewhere in the registry.
- Added `France` to the address (`12 rue charles porcher, 69009 Lyon` → `..., Lyon, France`), matching the convention for other French entries in this file.

Canonicalized and validated locally.

closes #1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)