### PR TITLE
Add WDBK - Wordbank LLC - studios.json

### DIFF
--- a/src/main/data/studios.json
+++ b/src/main/data/studios.json
@@ -4791,6 +4791,16 @@
     "url": "https://disneyanimation.com"
   },
   {
+    "code": "WDBK",
+    "contact": {
+      "address": "600 17th Street, Suite 715S, Denver, CO 80202, USA",
+      "email": "hans_damkoehler@wordbank.com",
+      "name": "Hans Damkoehler"
+    },
+    "description": "Wordbank LLC",
+    "url": "https://wordbank.com"
+  },
+  {
     "code": "WID",
     "contact": {
       "address": "02-969 Warsaw, Poland, ul. Andrutowa 15",


### PR DESCRIPTION
Processes #1463 (Google Form submission — `studios` / `form-submission`).

Adds studio code **WDBK** — Wordbank LLC (https://wordbank.com), with the contact info from the form submission (appended "USA" to the address, matching the convention for other US entries in this file).

Canonicalized and validated locally.

closes #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)